### PR TITLE
feat: add watch group management

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -360,3 +360,27 @@ button:hover, button:focus {
   color: #555;
 }
 
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+


### PR DESCRIPTION
## Summary
- add watch group state and default combinations
- provide dropdown to select watch groups and modal to manage them
- include styles for watch group modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996d05c6d483298032be51ca4e4b6d