### PR TITLE
feat: cache API responses

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import DividendCalendar from './DividendCalendar';
 
 import './App.css';
 import { API_HOST } from './config';
+import { fetchWithCache } from './api';
 
 const MONTHS = [
   'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
@@ -179,9 +180,7 @@ function App() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(`${API_HOST}:8000/get_dividend`);
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        const jsonData = await response.json();
+        const jsonData = await fetchWithCache(`${API_HOST}:8000/get_dividend`);
         setData(jsonData);
 
         const yearSet = new Set(jsonData.map(item => new Date(item.dividend_date).getFullYear()));
@@ -199,8 +198,7 @@ function App() {
   }, []);
 
   useEffect(() => {
-    fetch(`${API_HOST}:8000/get_stock_list`)
-      .then(res => res.json())
+    fetchWithCache(`${API_HOST}:8000/get_stock_list`)
       .then(list => {
         const map = {};
         const freqMapRaw = { '年配': 1, '半年配': 2, '季配': 4, '雙月配': 6, '月配': 12 };

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import Cookies from 'js-cookie';
 import Select from 'react-select';
 import { API_HOST } from './config';
+import { fetchWithCache } from './api';
 
 const COOKIE_KEY = 'my_transaction_history';
 const BACKUP_COOKIE_KEY = 'inventory_last_backup';
@@ -336,8 +337,7 @@ export default function InventoryTab() {
     }, [transactionHistory, handleExport]);
 
     useEffect(() => {
-        fetch(`${API_HOST}/get_stock_list`)
-            .then(res => res.json())
+        fetchWithCache(`${API_HOST}/get_stock_list`)
             .then(list => {
                 setStockList(list);
             })

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
 import { API_HOST } from './config';
+import { fetchWithCache } from './api';
 
 export default function StockDetail({ stockId }) {
   const [stock, setStock] = useState(null);
 
   useEffect(() => {
-    fetch(`${API_HOST}/get_stock_list`)
-      .then(res => res.json())
+    fetchWithCache(`${API_HOST}/get_stock_list`)
       .then(list => {
         const s = list.find(item => item.stock_id === stockId);
         setStock(s || {});

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,43 @@
+export async function fetchWithCache(url) {
+  const cacheKey = `cache:data:${url}`;
+  const metaKey = `cache:meta:${url}`;
+  const headers = {};
+
+  try {
+    const metaRaw = localStorage.getItem(metaKey);
+    if (metaRaw) {
+      const meta = JSON.parse(metaRaw);
+      if (meta.etag) {
+        headers['If-None-Match'] = meta.etag;
+      } else if (meta.lastModified) {
+        headers['If-Modified-Since'] = meta.lastModified;
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+
+  const response = await fetch(url, { headers });
+  if (response.status === 200) {
+    const data = await response.json();
+    const etag = response.headers.get('ETag');
+    const lastModified = response.headers.get('Last-Modified');
+    try {
+      localStorage.setItem(cacheKey, JSON.stringify(data));
+      localStorage.setItem(metaKey, JSON.stringify({ etag, lastModified }));
+    } catch {
+      // localStorage may be unavailable or full
+    }
+    return data;
+  }
+
+  if (response.status === 304) {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+    throw new Error('No cached data available');
+  }
+
+  throw new Error(`HTTP error! status: ${response.status}`);
+}


### PR DESCRIPTION
## Summary
- add `fetchWithCache` helper to store API responses and send conditional headers
- use cached fetching for dividend and stock list requests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997e6d46908329b9619e320347c286