### PR TITLE
feat: cache API responses with ETag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -121,6 +121,7 @@ function App() {
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [dataSource, setDataSource] = useState('latest');
 
   // Toggle table/calendar view
   const [showCalendar, setShowCalendar] = useState(false);
@@ -180,8 +181,9 @@ function App() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const jsonData = await fetchWithCache(`${API_HOST}:8000/get_dividend`);
+        const { data: jsonData, fromCache } = await fetchWithCache(`${API_HOST}:8000/get_dividend`);
         setData(jsonData);
+        setDataSource(fromCache ? 'cache' : 'latest');
 
         const yearSet = new Set(jsonData.map(item => new Date(item.dividend_date).getFullYear()));
         const yearList = Array.from(yearSet).sort((a, b) => b - a);
@@ -199,7 +201,7 @@ function App() {
 
   useEffect(() => {
     fetchWithCache(`${API_HOST}:8000/get_stock_list`)
-      .then(list => {
+      .then(({ data: list }) => {
         const map = {};
         const freqMapRaw = { '年配': 1, '半年配': 2, '季配': 4, '雙月配': 6, '月配': 12 };
         list.forEach(s => {
@@ -509,6 +511,7 @@ function App() {
       {tab === 'dividend' && (
         <div className="App">
           <h1>ETF 每月配息總表</h1>
+          <p style={{ fontSize: 12 }}>{dataSource === 'cache' ? '使用快取' : '最新'}</p>
           <div style={{ marginBottom: 16 }}>
             <label>年份：</label>
             <select

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -249,6 +249,7 @@ function SellModal({ show, stock, onClose, onSubmit }) {
 
 export default function InventoryTab() {
     const [stockList, setStockList] = useState([]);
+    const [stockListSource, setStockListSource] = useState('latest');
     const [transactionHistory, setTransactionHistory] = useState(getTransactionHistory());
     const [showModal, setShowModal] = useState(false);
     const [form, setForm] = useState({
@@ -338,8 +339,9 @@ export default function InventoryTab() {
 
     useEffect(() => {
         fetchWithCache(`${API_HOST}/get_stock_list`)
-            .then(list => {
+            .then(({ data: list, fromCache }) => {
                 setStockList(list);
+                setStockListSource(fromCache ? 'cache' : 'latest');
             })
             .catch(() => setStockList([]));
     }, []);
@@ -449,6 +451,7 @@ export default function InventoryTab() {
                     padding: '6px 18px', borderBottom: '2px solid #1e70b8'
                 }}>庫存管理</span>
             </div>
+            <p style={{ fontSize: 12 }}>{stockListSource === 'cache' ? '使用快取' : '最新'}</p>
             <p style={{ textAlign: 'left', marginBottom: 16 }}>
                 這是一個免費網站，我們不會把你的資料存到後台或伺服器，所有的紀錄（像是你的設定或操作紀錄）都只會保存在你的瀏覽器裡。簡單說：你的資料只在你這台電腦，不會上傳，也不會被我們看到，請安心使用！
             </p>

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -4,12 +4,14 @@ import { fetchWithCache } from './api';
 
 export default function StockDetail({ stockId }) {
   const [stock, setStock] = useState(null);
+  const [stockSource, setStockSource] = useState('latest');
 
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_stock_list`)
-      .then(list => {
+      .then(({ data: list, fromCache }) => {
         const s = list.find(item => item.stock_id === stockId);
         setStock(s || {});
+        setStockSource(fromCache ? 'cache' : 'latest');
       })
       .catch(() => setStock({}));
   }, [stockId]);
@@ -24,6 +26,7 @@ export default function StockDetail({ stockId }) {
 
   return (
     <div className="stock-detail">
+      <p style={{ fontSize: 12 }}>{stockSource === 'cache' ? '使用快取' : '最新'}</p>
       <h1>{stock.stock_id} {stock.stock_name}</h1>
       <p>配息頻率: {stock.dividend_frequency || '-'}</p>
       <p>保管銀行: {stock.custodian || '-'}</p>

--- a/src/api.js
+++ b/src/api.js
@@ -2,15 +2,16 @@ export async function fetchWithCache(url) {
   const cacheKey = `cache:data:${url}`;
   const metaKey = `cache:meta:${url}`;
   const headers = {};
+  let cachedMeta = null;
 
   try {
     const metaRaw = localStorage.getItem(metaKey);
     if (metaRaw) {
-      const meta = JSON.parse(metaRaw);
-      if (meta.etag) {
-        headers['If-None-Match'] = meta.etag;
-      } else if (meta.lastModified) {
-        headers['If-Modified-Since'] = meta.lastModified;
+      cachedMeta = JSON.parse(metaRaw);
+      if (cachedMeta.etag) {
+        headers['If-None-Match'] = cachedMeta.etag;
+      } else if (cachedMeta.lastModified) {
+        headers['If-Modified-Since'] = cachedMeta.lastModified;
       }
     }
   } catch {
@@ -22,19 +23,28 @@ export async function fetchWithCache(url) {
     const data = await response.json();
     const etag = response.headers.get('ETag');
     const lastModified = response.headers.get('Last-Modified');
+    const storedAt = new Date().toISOString();
     try {
       localStorage.setItem(cacheKey, JSON.stringify(data));
-      localStorage.setItem(metaKey, JSON.stringify({ etag, lastModified }));
+      localStorage.setItem(metaKey, JSON.stringify({ etag, lastModified, storedAt }));
     } catch {
       // localStorage may be unavailable or full
     }
-    return data;
+    return { data, fromCache: false, meta: { etag, lastModified, storedAt } };
   }
 
   if (response.status === 304) {
     const cached = localStorage.getItem(cacheKey);
     if (cached) {
-      return JSON.parse(cached);
+      try {
+        if (!cachedMeta) {
+          const metaRaw = localStorage.getItem(metaKey);
+          if (metaRaw) cachedMeta = JSON.parse(metaRaw);
+        }
+      } catch {
+        // ignore parse errors
+      }
+      return { data: JSON.parse(cached), fromCache: true, meta: cachedMeta };
     }
     throw new Error('No cached data available');
   }


### PR DESCRIPTION
## Summary
- cache API responses using ETag/Last-Modified and save metadata and timestamp
- surface cache status in dividend, inventory and stock detail views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998225c4ec8329bddd49f1bd131392