### PR TITLE
選擇觀察組合時重置所有篩選

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,6 +246,7 @@ function App() {
 
   const handleGroupChange = (e) => {
     const name = e.target.value;
+    handleResetFilters();
     setSelectedGroup(name);
     const group = watchGroups.find(g => g.name === name);
     if (group) {


### PR DESCRIPTION
## Summary
- reset all filters before applying selected watch group in App.jsx

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899fd142b7083298a7ea9e4fafe9a6c