### PR TITLE
fix: display watch group modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -405,7 +405,7 @@ button:active {
   z-index: 1000;
 }
 
-.modal {
+.custom-modal {
   background: #111;
   padding: 20px;
   border-radius: 8px;
@@ -415,5 +415,6 @@ button:active {
   overflow-y: auto;
   color: #f5f5f5;
   border: 1px solid #444;
+  display: block;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -757,7 +757,7 @@ function App() {
       </div>
       {showGroupModal && (
         <div className="modal-overlay">
-          <div className="modal">
+          <div className="custom-modal">
             <h3>觀察組合</h3>
             <div style={{ marginBottom: 10 }}>
               <button onClick={handleAddGroup}>新增組合</button>


### PR DESCRIPTION
## Summary
- show custom watch-group modal
- avoid Bootstrap `.modal` conflict

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a206c21188329b69221525e8a1356