### PR TITLE
Show top yield ETF in calendar with expandable list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -330,6 +330,15 @@ button:active {
 .event-pay {
   background: #4dabf7;
 }
+.more-btn {
+  margin-top: 4px;
+  font-size: 10px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: #0d6efd;
+  cursor: pointer;
+}
 .calendar-total {
   margin-top: 8px;
   text-align: right;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -520,9 +520,26 @@ function App() {
   // Prepare events for calendar view
   const calendarEvents = filteredData.flatMap(item => {
     const amount = parseFloat(item.dividend);
+    const dividend_yield = parseFloat(item.dividend_yield) || 0;
     const arr = [];
-    if (item.dividend_date) arr.push({ date: item.dividend_date, type: 'ex', stock_id: item.stock_id, amount });
-    if (item.payment_date) arr.push({ date: item.payment_date, type: 'pay', stock_id: item.stock_id, amount });
+    if (item.dividend_date) {
+      arr.push({
+        date: item.dividend_date,
+        type: 'ex',
+        stock_id: item.stock_id,
+        amount,
+        dividend_yield,
+      });
+    }
+    if (item.payment_date) {
+      arr.push({
+        date: item.payment_date,
+        type: 'pay',
+        stock_id: item.stock_id,
+        amount,
+        dividend_yield,
+      });
+    }
     return arr;
   });
 

--- a/src/DividendCalendar.jsx
+++ b/src/DividendCalendar.jsx
@@ -5,6 +5,7 @@ const DAY_NAMES = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 
 export default function DividendCalendar({ year, events }) {
   const [month, setMonth] = useState(new Date().getMonth());
+  const [expandedDates, setExpandedDates] = useState({});
   const todayStr = new Date().toISOString().slice(0, 10);
 
   const firstDay = new Date(year, month, 1);
@@ -20,7 +21,9 @@ export default function DividendCalendar({ year, events }) {
         week.push(null);
       } else {
         const dateStr = `${year}-${String(month+1).padStart(2,'0')}-${String(day).padStart(2,'0')}`;
-        const dayEvents = events.filter(e => e.date === dateStr);
+        const dayEvents = events
+          .filter(e => e.date === dateStr)
+          .sort((a, b) => (b.dividend_yield || 0) - (a.dividend_yield || 0));
         week.push({ day, dateStr, events: dayEvents, isToday: dateStr === todayStr });
       }
       day++;
@@ -61,7 +64,7 @@ export default function DividendCalendar({ year, events }) {
                   {d && (
                     <div>
                       <div className={`date-num${d.isToday ? ' today' : ''}`}>{d.day}</div>
-                      {d.events.map((ev, j) => (
+                      {(expandedDates[d.dateStr] ? d.events : d.events.slice(0,1)).map((ev, j) => (
                         <div
                           key={j}
                           className={`event ${ev.type === 'ex' ? 'event-ex' : 'event-pay'}`}
@@ -70,6 +73,14 @@ export default function DividendCalendar({ year, events }) {
                           {ev.stock_id}
                         </div>
                       ))}
+                      {!expandedDates[d.dateStr] && d.events.length > 1 && (
+                        <button
+                          className="more-btn"
+                          onClick={() => setExpandedDates(prev => ({ ...prev, [d.dateStr]: true }))}
+                        >
+                          更多+
+                        </button>
+                      )}
                     </div>
                   )}
                 </td>

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -52,9 +52,26 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const calendarEvents = filteredData.flatMap(item => {
         const qty = getHolding(item.stock_id, item.dividend_date);
         const amount = parseFloat(item.dividend) * qty;
+        const dividend_yield = parseFloat(item.dividend_yield) || 0;
         const arr = [];
-        if (item.dividend_date) arr.push({ date: item.dividend_date, type: 'ex', stock_id: item.stock_id, amount });
-        if (item.payment_date) arr.push({ date: item.payment_date, type: 'pay', stock_id: item.stock_id, amount });
+        if (item.dividend_date) {
+            arr.push({
+                date: item.dividend_date,
+                type: 'ex',
+                stock_id: item.stock_id,
+                amount,
+                dividend_yield,
+            });
+        }
+        if (item.payment_date) {
+            arr.push({
+                date: item.payment_date,
+                type: 'pay',
+                stock_id: item.stock_id,
+                amount,
+                dividend_yield,
+            });
+        }
         return arr;
     });
 


### PR DESCRIPTION
## Summary
- Show only the highest yield ETF on each calendar day and add a '更多+' toggle to reveal all ETFs
- Track dividend yield in calendar event data so days can be sorted by yield
- Style the new '更多+' button for the calendar view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df675dd1083298095deb8c2932c94