### PR TITLE
Add collapse button, fix payout color, and show calendar tooltips

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -328,7 +328,7 @@ button:active {
   background: #ff6b6b;
 }
 .event-pay {
-  background: #4dabf7;
+  background: #69db7c;
 }
 .more-btn {
   margin-top: 4px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -527,8 +527,12 @@ function App() {
         date: item.dividend_date,
         type: 'ex',
         stock_id: item.stock_id,
+        stock_name: item.stock_name,
         amount,
         dividend_yield,
+        last_close_price: item.last_close_price,
+        dividend_date: item.dividend_date,
+        payment_date: item.payment_date,
       });
     }
     if (item.payment_date) {
@@ -536,8 +540,12 @@ function App() {
         date: item.payment_date,
         type: 'pay',
         stock_id: item.stock_id,
+        stock_name: item.stock_name,
         amount,
         dividend_yield,
+        last_close_price: item.last_close_price,
+        dividend_date: item.dividend_date,
+        payment_date: item.payment_date,
       });
     }
     return arr;

--- a/src/DividendCalendar.jsx
+++ b/src/DividendCalendar.jsx
@@ -64,21 +64,35 @@ export default function DividendCalendar({ year, events }) {
                   {d && (
                     <div>
                       <div className={`date-num${d.isToday ? ' today' : ''}`}>{d.day}</div>
-                      {(expandedDates[d.dateStr] ? d.events : d.events.slice(0,1)).map((ev, j) => (
-                        <div
-                          key={j}
-                          className={`event ${ev.type === 'ex' ? 'event-ex' : 'event-pay'}`}
-                          title={`股息: ${Number(ev.amount).toFixed(1)}`}
-                        >
-                          {ev.stock_id}
-                        </div>
-                      ))}
+                      {(expandedDates[d.dateStr] ? d.events : d.events.slice(0,1)).map((ev, j) => {
+                        const tooltip = ev.quantity != null
+                          ? `持有數量: ${ev.quantity} 股\n每股配息: ${ev.dividend} 元\n應收股息: ${Number(ev.amount).toFixed(1)} 元\n除息前一天收盤價: ${ev.last_close_price}\n當次殖利率: ${ev.dividend_yield}%\n配息日期: ${ev.dividend_date || '-'}\n發放日期: ${ev.payment_date || '-'}`
+                          : `每股配息: ${Number(ev.amount).toFixed(3)} 元\n除息前一天收盤價: ${ev.last_close_price}\n當次殖利率: ${ev.dividend_yield}%\n配息日期: ${ev.dividend_date || '-'}\n發放日期: ${ev.payment_date || '-'}`;
+                        return (
+                          <div
+                            key={j}
+                            className={`event ${ev.type === 'ex' ? 'event-ex' : 'event-pay'}`}
+                            style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
+                            title={tooltip}
+                          >
+                            {ev.stock_id}
+                          </div>
+                        );
+                      })}
                       {!expandedDates[d.dateStr] && d.events.length > 1 && (
                         <button
                           className="more-btn"
                           onClick={() => setExpandedDates(prev => ({ ...prev, [d.dateStr]: true }))}
                         >
                           更多+
+                        </button>
+                      )}
+                      {expandedDates[d.dateStr] && d.events.length > 1 && (
+                        <button
+                          className="more-btn"
+                          onClick={() => setExpandedDates(prev => ({ ...prev, [d.dateStr]: false }))}
+                        >
+                          隱藏-
                         </button>
                       )}
                     </div>

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -51,7 +51,8 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     // Events for calendar view
     const calendarEvents = filteredData.flatMap(item => {
         const qty = getHolding(item.stock_id, item.dividend_date);
-        const amount = parseFloat(item.dividend) * qty;
+        const dividend = parseFloat(item.dividend);
+        const amount = dividend * qty;
         const dividend_yield = parseFloat(item.dividend_yield) || 0;
         const arr = [];
         if (item.dividend_date) {
@@ -59,8 +60,14 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                 date: item.dividend_date,
                 type: 'ex',
                 stock_id: item.stock_id,
+                stock_name: item.stock_name,
                 amount,
+                dividend,
+                quantity: qty,
                 dividend_yield,
+                last_close_price: item.last_close_price,
+                dividend_date: item.dividend_date,
+                payment_date: item.payment_date,
             });
         }
         if (item.payment_date) {
@@ -68,8 +75,14 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                 date: item.payment_date,
                 type: 'pay',
                 stock_id: item.stock_id,
+                stock_name: item.stock_name,
                 amount,
+                dividend,
+                quantity: qty,
                 dividend_yield,
+                last_close_price: item.last_close_price,
+                dividend_date: item.dividend_date,
+                payment_date: item.payment_date,
             });
         }
         return arr;


### PR DESCRIPTION
## Summary
- add collapse button to calendar cells to hide extra ETF entries
- align payout day color with legend
- show detailed ETF info on hover in calendar events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df82bede08329b9dd684684de4d07