### PR TITLE
Add natural language query helper panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -456,3 +456,57 @@ button:active {
   display: block;
 }
 
+
+/* Natural language helper panel */
+.nl-helper {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 100%;
+  background: #1a1a1a;
+  border-left: 1px solid #444;
+  padding: 12px;
+  box-shadow: -2px 0 6px rgba(0,0,0,0.5);
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+  color: #f5f5f5;
+}
+
+.nl-helper textarea {
+  width: 100%;
+  min-height: 80px;
+  margin-bottom: 8px;
+  background: #222;
+  border: 1px solid #555;
+  color: #f5f5f5;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.nl-helper button {
+  margin-bottom: 8px;
+  padding: 6px;
+  background: #333;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #d4af37;
+  cursor: pointer;
+}
+
+.nl-helper button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.nl-helper-response {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 8px;
+  white-space: pre-wrap;
+  font-size: 12px;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import AboutTab from './AboutTab';
 import DividendCalendar from './DividendCalendar';
 
 import './App.css';
+import NLHelper from './NLHelper';
 import { API_HOST } from './config';
 import { fetchWithCache } from './api';
 
@@ -956,6 +957,7 @@ function App() {
           .
         </p>
       </div>
+      <NLHelper />
       {showGroupModal && (
         <div className="modal-overlay">
           <div className="custom-modal">

--- a/src/NLHelper.jsx
+++ b/src/NLHelper.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { API_HOST } from './config';
+
+function NLHelper() {
+  const [query, setQuery] = useState('');
+  const [response, setResponse] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!query.trim()) return;
+    setLoading(true);
+    setResponse('');
+    try {
+      const res = await fetch(`${API_HOST}:8001/nl_query?q=${encodeURIComponent(query)}`);
+      if (!res.ok) {
+        setResponse(`Error: ${res.status}`);
+      } else {
+        const data = await res.json();
+        setResponse(JSON.stringify(data, null, 2));
+      }
+    } catch (err) {
+      setResponse('Error: ' + err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="nl-helper">
+      <textarea
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="輸入查詢..."
+      />
+      <button onClick={handleSubmit} disabled={loading}>
+        {loading ? '查詢中...' : '送出'}
+      </button>
+      <pre className="nl-helper-response">{response}</pre>
+    </div>
+  );
+}
+
+export default NLHelper;


### PR DESCRIPTION
## Summary
- add NLHelper React component to query new `/nl_query` endpoint
- style and mount a fixed helper panel on the right side of the app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ea08d77ec8329895fd2a551a85f49