### PR TITLE
feat: toggle NLHelper panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -472,6 +472,28 @@ button:active {
   flex-direction: column;
   z-index: 1000;
   color: #f5f5f5;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  pointer-events: none;
+}
+
+.nl-helper.open {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.nl-helper-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1001;
+  width: 40px;
+  height: 40px;
+  background: #1a1a1a;
+  border: 1px solid #444;
+  border-radius: 50%;
+  color: #d4af37;
+  cursor: pointer;
 }
 
 .nl-helper textarea {

--- a/src/NLHelper.jsx
+++ b/src/NLHelper.jsx
@@ -5,6 +5,7 @@ function NLHelper() {
   const [query, setQuery] = useState('');
   const [response, setResponse] = useState('');
   const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
 
   const handleSubmit = async () => {
     if (!query.trim()) return;
@@ -25,18 +26,25 @@ function NLHelper() {
     }
   };
 
+  const toggleOpen = () => setOpen(o => !o);
+
   return (
-    <div className="nl-helper">
-      <textarea
-        value={query}
-        onChange={e => setQuery(e.target.value)}
-        placeholder="輸入查詢..."
-      />
-      <button onClick={handleSubmit} disabled={loading}>
-        {loading ? '查詢中...' : '送出'}
+    <>
+      <div className={`nl-helper ${open ? 'open' : ''}`}>
+        <textarea
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="輸入查詢..."
+        />
+        <button onClick={handleSubmit} disabled={loading}>
+          {loading ? '查詢中...' : '送出'}
+        </button>
+        <pre className="nl-helper-response">{response}</pre>
+      </div>
+      <button className="nl-helper-toggle" onClick={toggleOpen}>
+        {open ? '×' : '🤖'}
       </button>
-      <pre className="nl-helper-response">{response}</pre>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- hide NLHelper panel by default and add a toggle button
- slide NLHelper into view when icon is clicked and hide on second click
- add styles for slide animation and floating toggle button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f300d49208329ac0a101717828955