### PR TITLE
feat: allow custom monthly income goal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -199,11 +199,18 @@ td {
   font-weight: 300;
 }
 
+table thead {
+  background: #111;
+  color: #ffd700;
+}
+
 .site-title {
   font-size: 2.5rem;
   font-weight: 600;
   text-align: center;
   margin-bottom: 8px;
+  color: #ffd700;
+  text-shadow: 0 0 8px rgba(255, 215, 0, 0.6);
 }
 
 .contact-section,
@@ -215,10 +222,11 @@ td {
 header {
   border-bottom: 1px solid #333;
   margin-bottom: 1rem;
-  padding: 0.75rem 0;
-  background: #222;
+  padding: 20px 0;
+  background: linear-gradient(135deg, #444, #000);
   box-shadow: 0 2px 4px rgba(255, 215, 0, 0.1);
   transition: box-shadow 0.3s;
+  border-radius: 12px;
 }
 
 header:hover {


### PR DESCRIPTION
## Summary
- let users input a monthly income target and update cost calculations accordingly
- memoize dividend data generation to avoid repeated work
- polish header and table styling with a gold theme for a richer feel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11734a25083298d907ba1f9fbde65