### PR TITLE
Fix ActionDropdown calendar toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -140,6 +140,7 @@ function ActionDropdown({
   openGroupModal,
   monthlyIncomeGoal,
   setMonthlyIncomeGoal,
+  showCalendar,
   onClose
 }) {
   const ref = useRef();
@@ -714,6 +715,7 @@ function App() {
                   openGroupModal={() => setShowGroupModal(true)}
                   monthlyIncomeGoal={monthlyIncomeGoal}
                   setMonthlyIncomeGoal={val => setMonthlyIncomeGoal(val)}
+                  showCalendar={showCalendar}
                   onClose={() => setShowActions(false)}
                 />
               )}


### PR DESCRIPTION
## Summary
- pass `showCalendar` state into `ActionDropdown`
- prevent undefined reference when calendar view is shown

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3afcd9e608329b2eecadcaf0a7beb