### PR TITLE
fix: improve calendar colors

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -290,7 +290,7 @@ button:active {
   background: #ff8fa3;
 }
 .legend-pay {
-  background: #69db7c;
+  background: #2f9e44;
 }
 .calendar-grid {
   width: 100%;
@@ -304,6 +304,7 @@ button:active {
   height: 100px;
   vertical-align: top;
   position: relative;
+  background: #f5f5f5;
 }
 
 .calendar-today {
@@ -336,7 +337,7 @@ button:active {
   background: #ff6b6b;
 }
 .event-pay {
-  background: #69db7c;
+  background: #2f9e44;
 }
 .more-btn {
   margin-top: 4px;


### PR DESCRIPTION
## Summary
- use light gray backgrounds for calendar cells
- darken payment-date highlights for better contrast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c142458c83299d6e87d6b8e40800