### PR TITLE
feat: add API cache metadata and status

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -295,11 +295,14 @@ function App() {
     };
   }, []);
 
+  const [dividendCacheInfo, setDividendCacheInfo] = useState(null);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const jsonData = await fetchWithCache(`${API_HOST}/get_dividend`);
+        const { data: jsonData, cacheStatus, timestamp } = await fetchWithCache(`${API_HOST}/get_dividend`);
         setData(jsonData);
+        setDividendCacheInfo({ cacheStatus, timestamp });
 
         const yearSet = new Set(jsonData.map(item => new Date(item.dividend_date).getFullYear()));
         const yearList = Array.from(yearSet).sort((a, b) => b - a);
@@ -317,7 +320,7 @@ function App() {
 
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_stock_list`)
-      .then(list => {
+      .then(({ data: list }) => {
         const map = {};
         const freqMapRaw = { '年配': 1, '半年配': 2, '季配': 4, '雙月配': 6, '月配': 12 };
         list.forEach(s => {
@@ -719,11 +722,11 @@ function App() {
                   onClose={() => setShowActions(false)}
                 />
               )}
-            </div>
-            <div style={{ display: 'inline-block', position: 'relative', marginLeft: 20 }}>
-              <button onClick={() => setShowDisplays(v => !v)}>更多顯示</button>
-              {showDisplays && (
-                <DisplayDropdown
+          </div>
+          <div style={{ display: 'inline-block', position: 'relative', marginLeft: 20 }}>
+            <button onClick={() => setShowDisplays(v => !v)}>更多顯示</button>
+            {showDisplays && (
+              <DisplayDropdown
                   toggleCalendar={() => setShowCalendar(v => !v)}
                   showCalendar={showCalendar}
                   toggleDiamond={() => setShowDiamondOnly(v => !v)}
@@ -737,6 +740,12 @@ function App() {
               )}
             </div>
           </div>
+          {dividendCacheInfo && (
+            <div style={{ textAlign: 'right', fontSize: 12 }}>
+              快取: {dividendCacheInfo.cacheStatus}
+              {dividendCacheInfo.timestamp ? ` (${new Date(dividendCacheInfo.timestamp).toLocaleString()})` : ''}
+            </div>
+          )}
           {!showCalendar && (
             <>
               <button onClick={handleResetFilters} style={{ marginRight: 10 }}>重置所有篩選</button>

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -250,6 +250,7 @@ export default function InventoryTab() {
     const [editForm, setEditForm] = useState({ date: '', quantity: '', price: '' });
     const [sellModal, setSellModal] = useState({ show: false, stock: null });
     const fileInputRef = useRef(null);
+    const [cacheInfo, setCacheInfo] = useState(null);
 
     const handleExport = useCallback(() => {
         const header = ['stock_id', 'date', 'quantity', 'type', 'price'];
@@ -325,7 +326,10 @@ export default function InventoryTab() {
 
     useEffect(() => {
         fetchWithCache(`${API_HOST}/get_stock_list`)
-            .then(list => setStockList(list))
+            .then(({ data: list, cacheStatus, timestamp }) => {
+                setStockList(list);
+                setCacheInfo({ cacheStatus, timestamp });
+            })
             .catch(() => setStockList([]));
     }, []);
 
@@ -428,6 +432,12 @@ export default function InventoryTab() {
             <p style={{ textAlign: 'left' }}>
                 這是一個免費網站，我們不會把你的資料存到後台或伺服器，所有的紀錄（像是你的設定或操作紀錄）都只會保存在你的瀏覽器裡。簡單說：你的資料只在你這台電腦，不會上傳，也不會被我們看到，請安心使用！
             </p>
+            {cacheInfo && (
+                <div style={{ textAlign: 'right', fontSize: 12 }}>
+                    快取: {cacheInfo.cacheStatus}
+                    {cacheInfo.timestamp ? ` (${new Date(cacheInfo.timestamp).toLocaleString()})` : ''}
+                </div>
+            )}
 
             <div style={{ textAlign: 'left', marginBottom: 0, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                 <button

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -5,13 +5,16 @@ import { fetchWithCache } from './api';
 export default function StockDetail({ stockId }) {
   const [stock, setStock] = useState(null);
   const [dividends, setDividends] = useState([]);
+  const [stockCacheInfo, setStockCacheInfo] = useState(null);
+  const [dividendCacheInfo, setDividendCacheInfo] = useState(null);
 
   // fetch stock basic info
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_stock_list`)
-      .then(list => {
+      .then(({ data: list, cacheStatus, timestamp }) => {
         const s = list.find(item => item.stock_id === stockId);
         setStock(s || {});
+        setStockCacheInfo({ cacheStatus, timestamp });
       })
       .catch(() => setStock({}));
   }, [stockId]);
@@ -19,10 +22,11 @@ export default function StockDetail({ stockId }) {
   // fetch dividend records
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_dividend`)
-      .then(data => {
+      .then(({ data, cacheStatus, timestamp }) => {
         const arr = data.filter(item => item.stock_id === stockId);
         arr.sort((a, b) => new Date(b.dividend_date) - new Date(a.dividend_date));
         setDividends(arr);
+        setDividendCacheInfo({ cacheStatus, timestamp });
       })
       .catch(() => setDividends([]));
   }, [stockId]);
@@ -42,6 +46,18 @@ export default function StockDetail({ stockId }) {
   return (
     <div className="stock-detail">
       <h1>{stock.stock_id} {stock.stock_name}</h1>
+      {stockCacheInfo && (
+        <div style={{ textAlign: 'right', fontSize: 12 }}>
+          基本資料快取: {stockCacheInfo.cacheStatus}
+          {stockCacheInfo.timestamp ? ` (${new Date(stockCacheInfo.timestamp).toLocaleString()})` : ''}
+        </div>
+      )}
+      {dividendCacheInfo && (
+        <div style={{ textAlign: 'right', fontSize: 12 }}>
+          配息資料快取: {dividendCacheInfo.cacheStatus}
+          {dividendCacheInfo.timestamp ? ` (${new Date(dividendCacheInfo.timestamp).toLocaleString()})` : ''}
+        </div>
+      )}
       <p>配息頻率: {stock.dividend_frequency || '-'}</p>
       <p>保管銀行: {stock.custodian || '-'}</p>
       <p>發行券商: {issuer || '-'}</p>

--- a/src/api.js
+++ b/src/api.js
@@ -2,11 +2,12 @@ export async function fetchWithCache(url) {
   const cacheKey = `cache:data:${url}`;
   const metaKey = `cache:meta:${url}`;
   const headers = {};
+  let meta;
 
   try {
     const metaRaw = localStorage.getItem(metaKey);
     if (metaRaw) {
-      const meta = JSON.parse(metaRaw);
+      meta = JSON.parse(metaRaw);
       if (meta.etag) {
         headers['If-None-Match'] = meta.etag;
       } else if (meta.lastModified) {
@@ -22,19 +23,20 @@ export async function fetchWithCache(url) {
     const data = await response.json();
     const etag = response.headers.get('ETag');
     const lastModified = response.headers.get('Last-Modified');
+    const timestamp = new Date().toISOString();
     try {
       localStorage.setItem(cacheKey, JSON.stringify(data));
-      localStorage.setItem(metaKey, JSON.stringify({ etag, lastModified }));
+      localStorage.setItem(metaKey, JSON.stringify({ etag, lastModified, timestamp }));
     } catch {
       // localStorage may be unavailable or full
     }
-    return data;
+    return { data, cacheStatus: 'fresh', timestamp };
   }
 
   if (response.status === 304) {
     const cached = localStorage.getItem(cacheKey);
     if (cached) {
-      return JSON.parse(cached);
+      return { data: JSON.parse(cached), cacheStatus: 'cached', timestamp: meta?.timestamp || null };
     }
     throw new Error('No cached data available');
   }


### PR DESCRIPTION
## Summary
- cache API responses with ETag/Last-Modified metadata and timestamp
- show cache status in dividend, inventory, and stock detail views

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ec8cdb348329979126853909e220