### PR TITLE
fix: ensure stock list is array

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -327,7 +327,10 @@ export default function InventoryTab() {
     useEffect(() => {
         fetchWithCache(`${API_HOST}/get_stock_list`)
             .then(({ data: list, cacheStatus, timestamp }) => {
-                setStockList(list);
+                const arr = Array.isArray(list)
+                    ? list
+                    : Array.isArray(list?.data) ? list.data : [];
+                setStockList(arr);
                 setCacheInfo({ cacheStatus, timestamp });
             })
             .catch(() => setStockList([]));


### PR DESCRIPTION
## Summary
- ensure fetched stock list is converted to an array before use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48c2a70b48329bd76d12913f05a7c