### PR TITLE
feat: refresh cache metadata on 304

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -36,7 +36,18 @@ export async function fetchWithCache(url) {
   if (response.status === 304) {
     const cached = localStorage.getItem(cacheKey);
     if (cached) {
-      return { data: JSON.parse(cached), cacheStatus: 'cached', timestamp: meta?.timestamp || null };
+      const etag = response.headers.get('ETag') || meta?.etag || null;
+      const lastModified = response.headers.get('Last-Modified') || meta?.lastModified || null;
+      const timestamp = new Date().toISOString();
+      try {
+        localStorage.setItem(
+          metaKey,
+          JSON.stringify({ etag, lastModified, timestamp })
+        );
+      } catch {
+        // ignore write errors
+      }
+      return { data: JSON.parse(cached), cacheStatus: 'cached', timestamp };
     }
     throw new Error('No cached data available');
   }


### PR DESCRIPTION
## Summary
- refresh cached metadata when server responds 304
- store new ETag/Last-Modified timestamps and return cached data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49471ca648329a5c5f2fec6579870