### PR TITLE
Handle paginated dividend API response

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -301,13 +301,14 @@ function App() {
     const fetchData = async () => {
       try {
         const { data: jsonData, cacheStatus, timestamp } = await fetchWithCache(`${API_HOST}/get_dividend`);
-        if (!Array.isArray(jsonData)) {
+        const arr = Array.isArray(jsonData) ? jsonData : jsonData?.items;
+        if (!Array.isArray(arr)) {
           throw new Error('Invalid data format');
         }
-        setData(jsonData);
+        setData(arr);
         setDividendCacheInfo({ cacheStatus, timestamp });
 
-        const yearSet = new Set(jsonData.map(item => new Date(item.dividend_date).getFullYear()));
+        const yearSet = new Set(arr.map(item => new Date(item.dividend_date).getFullYear()));
         const yearList = Array.from(yearSet).sort((a, b) => b - a);
         setYears(yearList);
         if (!yearSet.has(selectedYear)) setSelectedYear(yearList[0]);

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -23,7 +23,8 @@ export default function StockDetail({ stockId }) {
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_dividend`)
       .then(({ data, cacheStatus, timestamp }) => {
-        const arr = data.filter(item => item.stock_id === stockId);
+        const list = Array.isArray(data) ? data : data?.items || [];
+        const arr = list.filter(item => item.stock_id === stockId);
         arr.sort((a, b) => new Date(b.dividend_date) - new Date(a.dividend_date));
         setDividends(arr);
         setDividendCacheInfo({ cacheStatus, timestamp });


### PR DESCRIPTION
## Summary
- Handle new `/get_dividend` response shape by unwrapping `items`
- Ensure stock detail view parses cached dividend data correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49e5f39d48329be81303597a20af7