### PR TITLE
Fix lot calculation and stock list parsing

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -326,10 +326,14 @@ export default function InventoryTab() {
 
     useEffect(() => {
         fetchWithCache(`${API_HOST}/get_stock_list`)
-            .then(({ data: list, cacheStatus, timestamp }) => {
-                const arr = Array.isArray(list)
-                    ? list
-                    : Array.isArray(list?.data) ? list.data : [];
+            .then(({ data, cacheStatus, timestamp }) => {
+                const arr = Array.isArray(data)
+                    ? data
+                    : Array.isArray(data?.data)
+                        ? data.data
+                        : Array.isArray(data?.items)
+                            ? data.items
+                            : [];
                 setStockList(arr);
                 setCacheInfo({ cacheStatus, timestamp });
             })

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -11,7 +11,8 @@ export default function StockDetail({ stockId }) {
   // fetch stock basic info
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_stock_list`)
-      .then(({ data: list, cacheStatus, timestamp }) => {
+      .then(({ data, cacheStatus, timestamp }) => {
+        const list = Array.isArray(data) ? data : data?.items || [];
         const s = list.find(item => item.stock_id === stockId);
         setStock(s || {});
         setStockCacheInfo({ cacheStatus, timestamp });


### PR DESCRIPTION
## Summary
- correct monthly income lot calculation to convert between annual dividends and monthly goals
- handle get_stock_list API without limit parameter
- ensure stock detail fetch reads items array from API responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ae37d46883299c94ff3f693d8277