### PR TITLE
Enable ETag-based caching for NL helper API

### DIFF
--- a/src/NLHelper.jsx
+++ b/src/NLHelper.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { API_HOST } from './config';
+import { fetchWithCache } from './api';
 
 function NLHelper() {
   const [query, setQuery] = useState('');
@@ -12,13 +13,10 @@ function NLHelper() {
     setLoading(true);
     setResponse('');
     try {
-      const res = await fetch(`${API_HOST}/nl_query?q=${encodeURIComponent(query)}`);
-      if (!res.ok) {
-        setResponse(`Error: ${res.status}`);
-      } else {
-        const data = await res.json();
-        setResponse(JSON.stringify(data, null, 2));
-      }
+      const { data } = await fetchWithCache(
+        `${API_HOST}/nl_query?q=${encodeURIComponent(query)}`
+      );
+      setResponse(JSON.stringify(data, null, 2));
     } catch (err) {
       setResponse('Error: ' + err.message);
     } finally {


### PR DESCRIPTION
## Summary
- Use existing `fetchWithCache` helper in NLHelper component to honor ETag-based caching for natural language query endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7d46d4bf4832983017fd2cb0e44cf