### PR TITLE
chore: add docker ignore and ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.git
+.gitignore
+Dockerfile
+dockerfile
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 This project uses React + Vite. A Dockerfile is provided for serving the built app via Nginx.
 
-When working locally you will need to install dependencies before running lint or the development server:
+When working locally you will need to install dependencies before running lint or the development server. Use the included lockfile for reproducible installs:
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 ```
 
-Running `pnpm install` populates the `node_modules` folder which ESLint relies on. Without it commands like `pnpm run lint` will fail with missing package errors.
+Running `pnpm install --frozen-lockfile` populates the `node_modules` folder based on `pnpm-lock.yaml` so everyone uses the same dependency versions. Without it commands like `pnpm run lint` will fail with missing package errors.
 
-To build and run the production image:
+The `pnpm-lock.yaml` file should be kept under version control to guarantee identical installs in CI/CD and local environments.
+
+To build and run the production image the Dockerfile also installs dependencies from the lockfile:
 
 ```bash
 docker build -t etf-view .

--- a/dockerfile
+++ b/dockerfile
@@ -3,10 +3,10 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# 複製 package.json，安裝依賴
-COPY package.json ./
+# 複製 package.json 及鎖定檔後再安裝依賴，以利快取
+COPY package.json pnpm-lock.yaml ./
 
-RUN corepack enable && pnpm install
+RUN corepack enable && pnpm install --frozen-lockfile
 
 # 複製所有檔案
 COPY . .


### PR DESCRIPTION
## Summary
- ignore build output and modules in Docker contexts
- optimize Dockerfile with cacheable dependency install
- ensure CI installs using lockfile

## Testing
- `pnpm install` *(fails: request to registry.npmjs.org/@babel%2Fcore failed)*
- `pnpm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- `pnpm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ed27627c8329bb384829bc2ee9dd