### PR TITLE
Display upcoming dividend alerts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -45,6 +45,15 @@
   font-family: sans-serif;
 }
 
+.dividend-alert {
+  background: #333;
+  border: 1px solid #444;
+  color: #d4af37;
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+
 table {
   width: 100%;
   margin-top: 20px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import './App.css';
 import NLHelper from './NLHelper';
 import { API_HOST } from './config';
 import { fetchWithCache } from './api';
+import { getTomorrowDividendAlerts } from './dividendUtils';
 
 const DEFAULT_MONTHLY_GOAL = 10000;
 
@@ -47,6 +48,7 @@ function App() {
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [upcomingAlerts, setUpcomingAlerts] = useState([]);
 
   // Toggle table/calendar view
   const [showCalendar, setShowCalendar] = useState(false);
@@ -138,6 +140,10 @@ function App() {
     fetchData();
     // eslint-disable-next-line
   }, []);
+
+  useEffect(() => {
+    setUpcomingAlerts(getTomorrowDividendAlerts(data));
+  }, [data]);
 
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_stock_list`)
@@ -440,6 +446,15 @@ function App() {
         <h1 className="site-title">ETF Dividend Tracker</h1>
         <h2 className="slogan">compound interest is the most powerful force in the universe</h2>
       </header>
+      {upcomingAlerts.length > 0 && (
+        <div className="dividend-alert">
+          {upcomingAlerts.map(a => (
+            <div key={`${a.stock_id}-${a.type}`}>
+              {a.stock_name || a.stock_id} 明天即將{a.type === 'ex' ? '除息' : '配息'} 每股 {a.dividend} 元，預估領取 {Math.round(a.total).toLocaleString()} 元
+            </div>
+          ))}
+        </div>
+      )}
       <ul className="nav nav-tabs mb-1 justify-content-center">
         <li className="nav-item">
           <button

--- a/src/dividendUtils.js
+++ b/src/dividendUtils.js
@@ -1,0 +1,30 @@
+import { readTransactionHistory } from './transactionStorage';
+
+export function getTomorrowDividendAlerts(dividendData, history = readTransactionHistory()) {
+  if (!Array.isArray(dividendData) || dividendData.length === 0) return [];
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+  const holdings = {};
+  (history || []).forEach(item => {
+    const d = item.date || item.purchased_date;
+    if (!d) return;
+    if (new Date(d) <= tomorrow) {
+      const qty = Number(item.quantity) || 0;
+      holdings[item.stock_id] = (holdings[item.stock_id] || 0) + (item.type === 'sell' ? -qty : qty);
+    }
+  });
+  const alerts = [];
+  dividendData.forEach(item => {
+    const qty = holdings[item.stock_id];
+    if (!qty) return;
+    const dividend = parseFloat(item.dividend) || 0;
+    if (item.dividend_date === tomorrowStr) {
+      alerts.push({ stock_id: item.stock_id, stock_name: item.stock_name, type: 'ex', dividend, quantity: qty, total: dividend * qty });
+    }
+    if (item.payment_date === tomorrowStr) {
+      alerts.push({ stock_id: item.stock_id, stock_name: item.stock_name, type: 'pay', dividend, quantity: qty, total: dividend * qty });
+    }
+  });
+  return alerts;
+}

--- a/src/dividendUtils.test.js
+++ b/src/dividendUtils.test.js
@@ -1,0 +1,25 @@
+import { getTomorrowDividendAlerts } from './dividendUtils';
+
+describe('getTomorrowDividendAlerts', () => {
+  test('detects ex-dividend and payment events for tomorrow', () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+    const data = [
+      { stock_id: '0056', stock_name: 'ETF A', dividend_date: tomorrowStr, payment_date: null, dividend: '1.5' },
+      { stock_id: '0050', stock_name: 'ETF B', dividend_date: null, payment_date: tomorrowStr, dividend: '0.8' }
+    ];
+    const history = [
+      { stock_id: '0056', date: '2023-01-01', type: 'buy', quantity: 1000 },
+      { stock_id: '0050', date: '2023-01-01', type: 'buy', quantity: 2000 }
+    ];
+    const alerts = getTomorrowDividendAlerts(data, history);
+    expect(alerts).toHaveLength(2);
+    const exAlert = alerts.find(a => a.stock_id === '0056');
+    expect(exAlert.type).toBe('ex');
+    expect(exAlert.total).toBeCloseTo(1500);
+    const payAlert = alerts.find(a => a.stock_id === '0050');
+    expect(payAlert.type).toBe('pay');
+    expect(payAlert.total).toBeCloseTo(1600);
+  });
+});


### PR DESCRIPTION
## Summary
- highlight tomorrow's ex-dividend or payment events for held ETFs
- compute alerts based on transaction history and dividend data
- style alert banner for visibility and test utility logic

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8abb103b08329bba041d4869ea1ec