### PR TITLE
Improve mobile layout for dividend and inventory controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -550,3 +550,29 @@ button:active {
   white-space: pre-wrap;
   font-size: 12px;
 }
+
+/* Dividend tab controls */
+.dividend-controls {
+  margin-bottom: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.control-pair {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  gap: 4px;
+}
+
+.more-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.more-group .more-item {
+  position: relative;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -492,52 +492,58 @@ function App() {
       {tab === 'dividend' && (
         <div className="App">
           <h3>ETF 每月配息總表</h3>
-          <div style={{ marginBottom: 5 }}>
-            <label>年份：</label>
-            <select
-              value={selectedYear}
-              onChange={e => setSelectedYear(Number(e.target.value))}
-            >
-              {years.map(year => (
-                <option value={year} key={year}>{year}</option>
-              ))}
-            </select>
-            <label style={{ marginLeft: 20 }}>觀察組合：</label>
-            <select value={selectedGroup} onChange={handleGroupChange}>
-              <option value="">自選</option>
-              {watchGroups.map(g => (
-                <option key={g.name} value={g.name}>{g.name}</option>
-              ))}
-            </select>
-            <div style={{ display: 'inline-block', position: 'relative', marginLeft: 20 }}>
-              {!showCalendar &&
-                <button onClick={() => setShowActions(v => !v)}>更多功能</button>
-              }
-              {showActions && (
-                <ActionDropdown
-                  openGroupModal={() => setShowGroupModal(true)}
-                  monthlyIncomeGoal={monthlyIncomeGoal}
-                  setMonthlyIncomeGoal={val => setMonthlyIncomeGoal(val)}
-                  showCalendar={showCalendar}
-                  onClose={() => setShowActions(false)}
-                />
-              )}
-          </div>
-          <div style={{ display: 'inline-block', position: 'relative', marginLeft: 20 }}>
-            <button onClick={() => setShowDisplays(v => !v)}>更多顯示</button>
-            {showDisplays && (
-              <DisplayDropdown
-                  toggleCalendar={() => setShowCalendar(v => !v)}
-                  showCalendar={showCalendar}
-                  toggleDiamond={() => setShowDiamondOnly(v => !v)}
-                  showDiamondOnly={showDiamondOnly}
-                  toggleDividendYield={() => setShowDividendYield(v => !v)}
-                  showDividendYield={showDividendYield}
-                  toggleAxis={() => setShowInfoAxis(v => !v)}
-                  showInfoAxis={showInfoAxis}
-                  onClose={() => setShowDisplays(false)}
-                />
-              )}
+          <div className="dividend-controls">
+            <div className="control-pair">
+              <label>年份：</label>
+              <select
+                value={selectedYear}
+                onChange={e => setSelectedYear(Number(e.target.value))}
+              >
+                {years.map(year => (
+                  <option value={year} key={year}>{year}</option>
+                ))}
+              </select>
+            </div>
+            <div className="control-pair">
+              <label>觀察組合：</label>
+              <select value={selectedGroup} onChange={handleGroupChange}>
+                <option value="">自選</option>
+                {watchGroups.map(g => (
+                  <option key={g.name} value={g.name}>{g.name}</option>
+                ))}
+              </select>
+            </div>
+            <div className="more-group">
+              <div className="more-item">
+                {!showCalendar &&
+                  <button onClick={() => setShowActions(v => !v)}>更多功能</button>
+                }
+                {showActions && (
+                  <ActionDropdown
+                    openGroupModal={() => setShowGroupModal(true)}
+                    monthlyIncomeGoal={monthlyIncomeGoal}
+                    setMonthlyIncomeGoal={val => setMonthlyIncomeGoal(val)}
+                    showCalendar={showCalendar}
+                    onClose={() => setShowActions(false)}
+                  />
+                )}
+              </div>
+              <div className="more-item">
+                <button onClick={() => setShowDisplays(v => !v)}>更多顯示</button>
+                {showDisplays && (
+                  <DisplayDropdown
+                    toggleCalendar={() => setShowCalendar(v => !v)}
+                    showCalendar={showCalendar}
+                    toggleDiamond={() => setShowDiamondOnly(v => !v)}
+                    showDiamondOnly={showDiamondOnly}
+                    toggleDividendYield={() => setShowDividendYield(v => !v)}
+                    showDividendYield={showDividendYield}
+                    toggleAxis={() => setShowInfoAxis(v => !v)}
+                    showInfoAxis={showInfoAxis}
+                    onClose={() => setShowDisplays(false)}
+                  />
+                )}
+              </div>
             </div>
           </div>
           {dividendCacheInfo && (

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -228,12 +228,14 @@ export default function InventoryTab() {
         >
           新增購買紀錄
         </button>
-        <button className={styles.button} onClick={handleExport}>
-          匯出 CSV
-        </button>
-        <button className={styles.button} onClick={handleImportClick}>
-          匯入 CSV
-        </button>
+        <div className={styles.csvControls}>
+          <button className={styles.button} onClick={handleExport}>
+            匯出 CSV
+          </button>
+          <button className={styles.button} onClick={handleImportClick}>
+            匯入 CSV
+          </button>
+        </div>
         <input
           type="file"
           accept=".csv"

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -15,6 +15,11 @@
   flex-wrap: wrap;
 }
 
+.csvControls {
+  display: flex;
+  gap: 8px;
+}
+
 .button {
   padding: 6px 18px;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- Keep observation group label and dropdown together on dividend tab
- Align more functions and display buttons on a single row
- Group export and import CSV buttons together in inventory tab

## Testing
- `pnpm lint`
- `pnpm test` *(fails: TypeError: Cannot read properties of undefined (reading 'status') in fetchWithCache returns cached data when not expired)*

------
https://chatgpt.com/codex/tasks/task_e_68b52d7ac42c83298e0b4c20cee0cbda