### PR TITLE
fix: set fixed width for month columns

### DIFF
--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -6,6 +6,7 @@ const MONTHS = [
     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
 ];
+const MONTH_COL_WIDTH = 80;
 function getTransactionHistory() {
     return readTransactionHistory().map(item => ({
         stock_id: item.stock_id,
@@ -209,7 +210,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                             </span>
                         </th>
                         {MONTHS.map((m, idx) => (
-                            <th key={idx} className={idx === currentMonth ? 'current-month' : ''}>
+                            <th key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>
                                 <span className="sortable" onClick={() => handleSort(`month${idx}`)}>
                                     {m}
                                     {sortConfig.column === `month${idx}` && (
@@ -239,10 +240,10 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                 <td>{stock.stock_id} {stock.stock_name}</td>
                                 {MONTHS.map((m, idx) => {
                                     const cell = dividendTable[stock.stock_id][idx];
-                                    if (!cell || !cell.dividend || !cell.quantity) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''}></td>;
+                                    if (!cell || !cell.dividend || !cell.quantity) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}></td>;
                                     const total = cell.dividend * cell.quantity;
                                     return (
-                                        <td key={idx} className={idx === currentMonth ? 'current-month' : ''}>
+                                        <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>
                                             <span
                                                 title={`持有數量: ${cell.quantity} 股 (${(cell.quantity / 1000).toFixed(3).replace(/\.?0+$/, '')} 張)\n每股配息: ${cell.dividend} 元\n除息前一天收盤價: ${cell.last_close_price}\n當次殖利率: ${cell.dividend_yield}\n配息日期: ${cell.dividend_date || '-'}\n發放日期: ${cell.payment_date || '-'}`}
                                                 style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
@@ -270,7 +271,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     <tr style={{ background: '#ffe066', fontWeight: 'bold' }}>
                         <td>月合計</td>
                         {totalPerMonth.map((total, idx) => (
-                            <td key={idx} className={idx === currentMonth ? 'current-month' : ''}>{total > 0 ? Math.round(total).toLocaleString() : ''}</td>
+                            <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>{total > 0 ? Math.round(total).toLocaleString() : ''}</td>
                         ))}
                         <td>
                             {grandTotal > 0 ? (

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -116,10 +116,10 @@ export default function StockTable({
             {stock.stock_id} {stock.stock_name}
           </a>
         </td>
-        <td style={{ maxWidth: NUM_COL_WIDTH }}>{latestPrice[stock.stock_id]?.price ?? ''}</td>
+        <td style={{ width: NUM_COL_WIDTH }}>{latestPrice[stock.stock_id]?.price ?? ''}</td>
         {MONTHS.map((m, idx) => {
           const cell = dividendTable[stock.stock_id] && dividendTable[stock.stock_id][idx];
-          if (!cell) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ maxWidth: NUM_COL_WIDTH }}></td>;
+          if (!cell) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}></td>;
           const freq = freqMap[stock.stock_id];
           const perYield = cell.perYield || 0;
           const displayVal = showDividendYield
@@ -128,7 +128,7 @@ export default function StockTable({
           const price = latestPrice[stock.stock_id]?.price;
           const extraInfo = getIncomeGoalInfo(cell.dividend, price, monthlyIncomeGoal, freq || 12);
           return (
-            <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ maxWidth: NUM_COL_WIDTH }}>
+            <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}>
               <span
                 title={`除息前一天收盤價: ${cell.last_close_price}\n當次殖利率: ${cell.dividend_yield}%\n平均月殖利率: ${perYield.toFixed(2)}%\n配息頻率: ${freqNameMap[freq] || '不定期'}\n配息日期: ${cell.dividend_date}\n發放日期: ${cell.payment_date}${extraInfo}`}
               >
@@ -241,7 +241,7 @@ export default function StockTable({
                 />
               )}
             </th>
-            <th style={{ maxWidth: NUM_COL_WIDTH }}>
+            <th style={{ width: NUM_COL_WIDTH }}>
               <span className="sortable" onClick={() => handleSort('latest_price')}>
                 最新<br></br>股價
                 <span className="sort-indicator">
@@ -252,7 +252,7 @@ export default function StockTable({
               </span>
             </th>
             {MONTHS.map((m, idx) => (
-              <th key={m} className={idx === currentMonth ? 'current-month' : ''} style={{ maxWidth: NUM_COL_WIDTH }}>
+              <th key={m} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}>
                 <span className="sortable" onClick={() => handleSort(`month${idx}`)}>
                   {m}
                   <span className="sort-indicator">


### PR DESCRIPTION
## Summary
- ensure month headers and cells have a fixed width so layout stays consistent

## Testing
- `npm test` *(fails: fetchWithCache › returns cached data when not expired: TypeError: Cannot read properties of undefined (reading 'status'))*

------
https://chatgpt.com/codex/tasks/task_e_68b625d363e48329a286435603926ccf