### PR TITLE
feat: add responsive table scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -400,8 +400,7 @@ button:active {
 .table-responsive {
   width: 100%;
   overflow-x: auto;
-  /* 可選: */
-  min-width: 550px;
+  -webkit-overflow-scrolling: touch;
 }
 
 @media (max-width: 576px) {

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -15,7 +15,7 @@ describe('InventoryTab interactions', () => {
     localStorage.clear();
     Cookies.remove('my_transaction_history');
     fetchWithCache.mockResolvedValue({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
-    global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+    globalThis.fetch = jest.fn(() => Promise.resolve({ ok: true }));
   });
 
   test('edits existing transaction', async () => {
@@ -42,8 +42,8 @@ describe('InventoryTab interactions', () => {
     render(<InventoryTab />);
     await waitFor(() => screen.getByText('顯示：交易歷史'));
     fireEvent.click(screen.getByText('同步到 Google Sheet'));
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    expect(global.fetch).toHaveBeenCalledWith(
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://example.com/sync',
       expect.objectContaining({ method: 'POST' })
     );

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -84,24 +84,26 @@ export default function StockDetail({ stockId }) {
         以上連結皆為第三方外部網站，資料內容由各網站提供，本網站不對其內容的正確性與即時性負責。
       </p>
       {dividends.length > 0 && (
-        <table className="dividend-record">
-          <thead>
-            <tr>
-              <th>日期</th>
-              <th>配息金額</th>
-              <th>殖利率</th>
-            </tr>
-          </thead>
-          <tbody>
-            {dividends.map(item => (
-              <tr key={item.dividend_date}>
-                <td>{item.dividend_date}</td>
-                <td>{item.dividend}</td>
-                <td>{item.dividend_yield}</td>
+        <div className="table-responsive">
+          <table className="dividend-record">
+            <thead>
+              <tr>
+                <th>日期</th>
+                <th>配息金額</th>
+                <th>殖利率</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {dividends.map(item => (
+                <tr key={item.dividend_date}>
+                  <td>{item.dividend_date}</td>
+                  <td>{item.dividend}</td>
+                  <td>{item.dividend_yield}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -151,7 +151,7 @@ export default function StockTable({
 
   if (showInfoAxis) {
     return (
-      <div className="table-responsive" style={{ overflowX: 'auto', display: 'block' }}>
+      <div className="table-responsive">
         {showAllStocks && (
           <button onClick={() => setShowAllStocks(false)} style={{ marginBottom: 8 }}>預設</button>
         )}
@@ -208,11 +208,11 @@ export default function StockTable({
   }
 
   return (
-    <div className="table-responsive" style={{ minWidth: 1300 }}>
+    <div className="table-responsive">
       {showAllStocks && (
         <button onClick={() => setShowAllStocks(false)} style={{ marginBottom: 8 }}>預設</button>
       )}
-      <table className="table table-bordered table-striped">
+      <table className="table table-bordered table-striped" style={{ minWidth: 1300 }}>
         <thead>
           <tr>
             <th style={{ position: 'relative' }}>


### PR DESCRIPTION
## Summary
- allow tables to scroll horizontally on small screens
- wrap stock detail tables in responsive containers
- fix test setup to use `globalThis.fetch`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ed1caefc83298c09007f52d71903