### PR TITLE
Allow entering Google Sheet URL

### DIFF
--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -20,6 +20,13 @@
   gap: 8px;
 }
 
+.gsheetInput {
+  padding: 6px;
+  border-radius: 6px;
+  border: 1px solid #888;
+  flex: 1;
+}
+
 .button {
   padding: 6px 18px;
   border-radius: 6px;

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -7,7 +7,7 @@ import { fetchWithCache } from './api';
 jest.mock('./api');
 jest.mock('./config', () => ({
   API_HOST: 'http://localhost',
-  GSHEET_URL: 'https://example.com/sync'
+  DEFAULT_GSHEET_URL: ''
 }));
 
 describe('InventoryTab interactions', () => {
@@ -41,6 +41,7 @@ describe('InventoryTab interactions', () => {
     ]));
     render(<InventoryTab />);
     await waitFor(() => screen.getByText('顯示：交易歷史'));
+    fireEvent.change(screen.getByPlaceholderText('Google Sheet URL'), { target: { value: 'https://example.com/sync' } });
     fireEvent.click(screen.getByText('同步到 Google Sheet'));
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(globalThis.fetch).toHaveBeenCalledWith(

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,2 @@
 export const API_HOST = import.meta.env.VITE_API_HOST;
-export const GSHEET_URL = import.meta.env.VITE_GSHEET_URL;
+export const DEFAULT_GSHEET_URL = import.meta.env.VITE_GSHEET_URL;


### PR DESCRIPTION
## Summary
- Support saving and syncing with a user-provided Google Sheet URL
- Expose default Google Sheet URL from configuration
- Test Google Sheet sync via user-entered URL

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f565754083299aa8f7ec9aeb4eae