### PR TITLE
Reload page after Drive and CSV import

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -75,7 +75,10 @@ export default function InventoryTab() {
         }
       }
       setTransactionHistory(list);
+      saveTransactionHistory(list);
       e.target.value = '';
+      alert('已匯入完成');
+      if (typeof window !== 'undefined') window.location.reload();
     };
     reader.readAsText(file);
   };

--- a/src/driveSync.js
+++ b/src/driveSync.js
@@ -160,6 +160,7 @@ export async function importFromDrive() {
       if (v !== null && v !== undefined) localStorage.setItem(k, v);
     });
     alert("已匯入完成");
+    if (typeof window !== 'undefined') window.location.reload();
   } catch (err) {
     console.error(err);
     alert(`匯入失敗：${err.message || err}`);


### PR DESCRIPTION
## Summary
- Reload page after finishing a Google Drive import so newly loaded data is visible immediately
- Reload page after CSV import to persist imported data and refresh the interface

## Testing
- `pnpm test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a376207c8329b48d0ecea8709b20