### PR TITLE
localize tables and improve ui

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -405,6 +405,13 @@ button:active {
   -webkit-overflow-scrolling: touch;
 }
 
+.table-responsive thead th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 1;
+}
+
 @media (max-width: 576px) {
   .table td, .table th {
     padding: 0.3rem;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -626,21 +626,20 @@ function App() {
       {tab === 'about' && <AboutTab />}
       <div className="contact-section">
         <h3>Contact</h3>
-        <p>Email: <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a></p>
+        <p>信箱：<a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a></p>
       </div>
       <div className="donation-section">
-        <h3>Support This Project</h3>
+        <h3>分享小小的分紅</h3>
         <p>
-          If you like this project, consider
-          {' '}
+          如果你喜歡這個專案，歡迎
           <a
             href="https://www.buymeacoffee.com/example"
             target="_blank"
             rel="noreferrer"
           >
-            donating
+            贊助
           </a>
-          .
+          。
         </p>
       </div>
       <NLHelper />

--- a/src/FintechLanding.jsx
+++ b/src/FintechLanding.jsx
@@ -214,7 +214,7 @@ export default function FintechLanding() {
         </div>
       </section>
 
-      <footer className="border-t border-[var(--border)]">
+      <footer className="border-t border-[var(--border)] bg-gray-100">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10">
           <div className="flex flex-col md:flex-row items-center justify-between gap-4">
             <div className="flex items-center gap-3">
@@ -222,9 +222,9 @@ export default function FintechLanding() {
               <span className="text-sm text-[var(--muted)]">© {new Date().getFullYear()} Aureo Fintech</span>
             </div>
             <div className="flex gap-5 text-sm text-[var(--muted)]">
-              <a href="#">Privacy</a>
-              <a href="#">Terms</a>
-              <a href="#">Security</a>
+              <a href="#">隱私</a>
+              <a href="#">條款</a>
+              <a href="#">安全</a>
             </div>
           </div>
         </div>

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -316,8 +316,7 @@ export default function InventoryTab() {
                 <thead>
                   <tr>
                     <th style={{ width: 30 }}>#</th>
-                    <th>代碼</th>
-                    <th>名稱</th>
+                    <th>股票代碼/名稱</th>
                     <th>平均股價</th>
                     <th>總數量</th>
                     <th>操作</th>
@@ -329,8 +328,7 @@ export default function InventoryTab() {
                     : inventoryList.map((item, idx) => (
                         <tr key={idx}>
                           <td>{idx + 1}</td>
-                          <td>{item.stock_id}</td>
-                          <td>{item.stock_name}</td>
+                          <td>{item.stock_id} {item.stock_name}</td>
                           <td>{item.avg_price.toFixed(2)}</td>
                           <td>{item.total_quantity} ({(item.total_quantity / 1000).toFixed(3).replace(/\.0+$/, '')} 張)</td>
                           <td>

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -34,11 +34,11 @@ export default function StockDetail({ stockId }) {
   }, [stockId]);
 
   if (!stock) {
-    return <div>Loading...</div>;
+    return <div>載入中...</div>;
   }
 
   if (!stock.stock_id) {
-    return <div style={{ padding: 20 }}>Stock not found.</div>;
+    return <div style={{ padding: 20 }}>找不到股票</div>;
   }
 
   const issuer = stock.issuer || stock.securities_firm || stock.broker;

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -3,8 +3,8 @@ import DividendCalendar from './components/DividendCalendar';
 import { readTransactionHistory } from './transactionStorage';
 
 const MONTHS = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    '1月', '2月', '3月', '4月', '5月', '6月',
+    '7月', '8月', '9月', '10月', '11月', '12月'
 ];
 const MONTH_COL_WIDTH = 80;
 function getTransactionHistory() {
@@ -203,7 +203,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     <tr>
                         <th>
                             <span className="sortable" onClick={() => handleSort('stock_id')}>
-                                Stock
+                                股票代碼/名稱
                                 {sortConfig.column === 'stock_id' && (
                                     <span className="sort-indicator">{sortConfig.direction === 'asc' ? '▲' : '▼'}</span>
                                 )}
@@ -221,7 +221,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                         ))}
                         <th>
                             <span className="sortable" onClick={() => handleSort('total')}>
-                                Total
+                                總計
                                 {sortConfig.column === 'total' && (
                                     <span className="sort-indicator">{sortConfig.direction === 'asc' ? '▲' : '▼'}</span>
                                 )}

--- a/src/components/DividendCalendar.jsx
+++ b/src/components/DividendCalendar.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
-const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-const DAY_NAMES = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+const MONTH_NAMES = ['1月','2月','3月','4月','5月','6月','7月','8月','9月','10月','11月','12月'];
+const DAY_NAMES = ['日','一','二','三','四','五','六'];
 
 export default function DividendCalendar({ year, events }) {
   const timeZone = 'Asia/Taipei';
@@ -36,9 +36,9 @@ export default function DividendCalendar({ year, events }) {
   const prevMonth = () => setMonth(m => (m === 0 ? 11 : m - 1));
   const nextMonth = () => setMonth(m => (m === 11 ? 0 : m + 1));
 
-  const monthTotal = events
-    .filter(e => new Date(e.date).getFullYear() === year && new Date(e.date).getMonth() === month)
-    .reduce((sum, e) => sum + Number(e.amount || 0), 0);
+  const monthEvents = events.filter(e => new Date(e.date).getFullYear() === year && new Date(e.date).getMonth() === month);
+  const exTotal = monthEvents.filter(e => e.type === 'ex').reduce((sum, e) => sum + Number(e.amount || 0), 0);
+  const payTotal = monthEvents.filter(e => e.type === 'pay').reduce((sum, e) => sum + Number(e.amount || 0), 0);
 
   return (
     <div className="calendar">
@@ -109,7 +109,7 @@ export default function DividendCalendar({ year, events }) {
         </tbody>
       </table>
       </div>
-      <div className="calendar-total">當月合計: {monthTotal.toFixed(1)}</div>
+      <div className="calendar-total">當月除息合計: {exTotal.toFixed(1)} / 發放合計: {payTotal.toFixed(1)}</div>
     </div>
   );
 }

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -3,8 +3,8 @@ import { useState, useMemo } from 'react';
 import FilterDropdown from './FilterDropdown';
 
 const MONTHS = [
-  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+  '1月', '2月', '3月', '4月', '5月', '6月',
+  '7月', '8月', '9月', '10月', '11月', '12月'
 ];
 
 const NUM_COL_WIDTH = 80;

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -71,7 +71,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
                     )}
                   </td>
                   <td>{item.type === 'sell' ? '賣出' : '買入'}</td>
-                  <td>
+                  <td className={styles.operationCol}>
                     {isEditing ? (
                       <>
                         <button onClick={() => handleEditSave(idx)}>儲存</button>

--- a/src/components/TransactionHistoryTable.module.css
+++ b/src/components/TransactionHistoryTable.module.css
@@ -13,3 +13,10 @@
 .actionButton {
   margin-left: 6px;
 }
+
+@media (max-width: 600px) {
+  .operationCol button {
+    width: 2em;
+    padding: 2px;
+  }
+}


### PR DESCRIPTION
## Summary
- add gray footer background and translate footer links to Chinese
- merge code and name into single stock column and localize table headings
- localize calendar labels and split monthly totals for ex-date vs payment
- freeze table headers and tweak mobile operation buttons

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c0a237c883299b2d974100c93fbe