### PR TITLE
Localize about page and improve tables

### DIFF
--- a/src/AboutTab.jsx
+++ b/src/AboutTab.jsx
@@ -3,16 +3,12 @@ import React from 'react';
 export default function AboutTab() {
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h1 className="mt-4">About This Project</h1>
+      <h1 className="mt-4">關於這個專案</h1>
       <p>
-        This website provides a consolidated view of ETF dividend information and
-        simple tools for tracking personal holdings. All data is for
-        informational purposes only and should not be considered financial
-        advice.
+        本網站提供 ETF 配息資訊的統整，以及簡易的持股追蹤工具。所有資料僅供參考，並非投資建議。
       </p>
       <p>
-        Source code is available on GitHub. Feedback and contributions are
-        welcome!
+        原始碼已開放在 GitHub，歡迎提供回饋與貢獻！
       </p>
     </div>
   );

--- a/src/AboutTab.test.jsx
+++ b/src/AboutTab.test.jsx
@@ -5,6 +5,6 @@ import AboutTab from './AboutTab';
 test('renders about heading', () => {
   render(<AboutTab />);
   expect(
-    screen.getByRole('heading', { name: /About This Project/i })
+    screen.getByRole('heading', { name: /關於這個專案/ })
   ).toBeInTheDocument();
 });

--- a/src/App.css
+++ b/src/App.css
@@ -412,6 +412,18 @@ button:active {
   z-index: 1;
 }
 
+.table-responsive table th:first-child,
+.table-responsive table td:first-child {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 2;
+}
+
+.table-responsive thead th:first-child {
+  z-index: 3;
+}
+
 @media (max-width: 576px) {
   .table td, .table th {
     padding: 0.3rem;

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -316,7 +316,6 @@ export default function InventoryTab() {
               <table className={`table table-bordered table-striped ${styles.fullWidth}`}>
                 <thead>
                   <tr>
-                    <th style={{ width: 30 }}>#</th>
                     <th>股票代碼/名稱</th>
                     <th>平均股價</th>
                     <th>總數量</th>
@@ -325,15 +324,14 @@ export default function InventoryTab() {
                 </thead>
                 <tbody>
                   {inventoryList.length === 0
-                    ? <tr><td colSpan={5}>尚無庫存</td></tr>
+                    ? <tr><td colSpan={4}>尚無庫存</td></tr>
                     : inventoryList.map((item, idx) => (
                         <tr key={idx}>
-                          <td>{idx + 1}</td>
-                          <td>{item.stock_id} {item.stock_name}</td>
+                          <td>{item.stock_id} {item.stock_name || (stockList.find(s => s.stock_id === item.stock_id)?.stock_name || '')}</td>
                           <td>{item.avg_price.toFixed(2)}</td>
                           <td>{item.total_quantity} ({(item.total_quantity / 1000).toFixed(3).replace(/\.0+$/, '')} 張)</td>
                           <td>
-                            <button onClick={() => setSellModal({ show: true, stock: item })}>賣出</button>
+                            <button className={styles.sellButton} onClick={() => setSellModal({ show: true, stock: item })}>賣出</button>
                           </td>
                         </tr>
                       ))}

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -41,3 +41,8 @@
 .fullWidth {
   width: 100%;
 }
+
+.sellButton {
+  min-width: 48px;
+  white-space: nowrap;
+}

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -23,7 +23,7 @@ describe('InventoryTab interactions', () => {
     render(<InventoryTab />);
     await waitFor(() => screen.getByText('顯示：交易歷史'));
     fireEvent.click(screen.getByText('顯示：交易歷史'));
-    await screen.findByText('0050');
+    await screen.findByText(/0050/);
     fireEvent.click(screen.getByText('修改'));
     const qtyInput = screen.getByDisplayValue('1000');
     fireEvent.change(qtyInput, { target: { value: '2000' } });

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -187,7 +187,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
 
     return (
         <div className="App" style={{ margin: '0 auto' }}>
-            <div style={{ display: "flex", alignItems: "center", margin: "10px 0 0 0"}}>
+            <div style={{ display: "flex", alignItems: "center", margin: "10px 0 0 0", gap: "8px"}}>
                 <h3>{selectedYear} 配息總覽</h3>
                 <button onClick={() => setShowCalendar(v => !v)}>
                     {showCalendar ? '顯示表格' : '顯示月曆'}

--- a/src/components/DividendCalendar.jsx
+++ b/src/components/DividendCalendar.jsx
@@ -51,6 +51,7 @@ export default function DividendCalendar({ year, events }) {
         <span><span className="legend-box legend-ex"></span>除息日</span>
         <span style={{ marginLeft: 8 }}><span className="legend-box legend-pay"></span>發放日</span>
       </div>
+      <div className="calendar-total">當月除息合計: {exTotal.toFixed(1)} / 發放合計: {payTotal.toFixed(1)}</div>
       <div className="table-responsive">
       <table className="calendar-grid">
         <thead>
@@ -109,7 +110,6 @@ export default function DividendCalendar({ year, events }) {
         </tbody>
       </table>
       </div>
-      <div className="calendar-total">當月除息合計: {exTotal.toFixed(1)} / 發放合計: {payTotal.toFixed(1)}</div>
     </div>
   );
 }

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -6,8 +6,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
       <table className={`table table-bordered table-striped ${styles.table}`}>
         <thead>
           <tr>
-            <th>代碼</th>
-            <th>名稱</th>
+            <th>股票代碼/名稱</th>
             <th>交易日期</th>
             <th>數量(股)</th>
             <th>價格(元)</th>
@@ -24,8 +23,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
               const isEditing = editingIdx === idx;
               return (
                 <tr key={idx}>
-                  <td>{item.stock_id}</td>
-                  <td>{stock.stock_name || ''}</td>
+                  <td>{item.stock_id} {stock.stock_name || ''}</td>
                   <td>
                     {isEditing ? (
                       <input


### PR DESCRIPTION
## Summary
- Translate About page content and test into Chinese
- Fix inventory and history tables: merge code/name column, show stock names, keep first column sticky, prevent sell button from shrinking
- Adjust dividend overview layout with spacing and totals above calendar

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba493ff4d88329830573396ad7db95