### PR TITLE
Fix sticky column and stock name display

### DIFF
--- a/src/AboutTab.jsx
+++ b/src/AboutTab.jsx
@@ -3,12 +3,12 @@ import React from 'react';
 export default function AboutTab() {
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h1 className="mt-4">關於這個專案</h1>
+      <h1 className="mt-4">關於本站</h1>
       <p>
-        本網站提供 ETF 配息資訊的統整，以及簡易的持股追蹤工具。所有資料僅供參考，並非投資建議。
+        哈囉～這裡是個幫你整理 ETF 配息的小天地，也附上簡單的持股追蹤工具。資料僅供參考，不構成投資建議唷！
       </p>
       <p>
-        原始碼已開放在 GitHub，歡迎提供回饋與貢獻！
+        這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～
       </p>
     </div>
   );

--- a/src/AboutTab.test.jsx
+++ b/src/AboutTab.test.jsx
@@ -5,6 +5,6 @@ import AboutTab from './AboutTab';
 test('renders about heading', () => {
   render(<AboutTab />);
   expect(
-    screen.getByRole('heading', { name: /關於這個專案/ })
+    screen.getByRole('heading', { name: /關於本站/ })
   ).toBeInTheDocument();
 });

--- a/src/App.css
+++ b/src/App.css
@@ -424,6 +424,11 @@ button:active {
   z-index: 3;
 }
 
+.stock-col {
+  width: 140px;
+  min-width: 140px;
+}
+
 @media (max-width: 576px) {
   .table td, .table th {
     padding: 0.3rem;

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -19,7 +19,7 @@ export default function InventoryTab() {
   const [stockList, setStockList] = useState([]);
   const [transactionHistory, setTransactionHistory] = useState(() => migrateTransactionHistory());
   const [showModal, setShowModal] = useState(false);
-  const [form, setForm] = useState({ stock_id: '', date: getToday(), quantity: '', price: '' });
+  const [form, setForm] = useState({ stock_id: '', stock_name: '', date: getToday(), quantity: '', price: '' });
   const [showInventory, setShowInventory] = useState(true);
   const [editingIdx, setEditingIdx] = useState(null);
   const [editForm, setEditForm] = useState({ date: '', quantity: '', price: '' });
@@ -148,7 +148,7 @@ export default function InventoryTab() {
       const s = stockList.find(x => x.stock_id === item.stock_id) || {};
       inventoryMap[item.stock_id] = {
         stock_id: item.stock_id,
-        stock_name: s.stock_name || '',
+        stock_name: s.stock_name || item.stock_name || '',
         total_quantity: 0,
         total_cost: 0
       };
@@ -188,7 +188,7 @@ export default function InventoryTab() {
         type: 'buy'
       }
     ]);
-    setForm({ stock_id: '', date: getToday(), quantity: '', price: '' });
+    setForm({ stock_id: '', stock_name: '', date: getToday(), quantity: '', price: '' });
     setShowModal(false);
   };
 
@@ -225,7 +225,7 @@ export default function InventoryTab() {
     }
     setTransactionHistory([
       ...transactionHistory,
-      { stock_id, date: getToday(), quantity: Number(qty), type: 'sell' }
+      { stock_id, stock_name: stock.stock_name, date: getToday(), quantity: Number(qty), type: 'sell' }
     ]);
     setSellModal({ show: false, stock: null });
   };
@@ -240,7 +240,7 @@ export default function InventoryTab() {
         <button
           className={styles.button}
           onClick={() => {
-            setForm({ stock_id: '', date: getToday(), quantity: '', price: '' });
+            setForm({ stock_id: '', stock_name: '', date: getToday(), quantity: '', price: '' });
             setShowModal(true);
           }}
         >
@@ -316,7 +316,7 @@ export default function InventoryTab() {
               <table className={`table table-bordered table-striped ${styles.fullWidth}`}>
                 <thead>
                   <tr>
-                    <th>股票代碼/名稱</th>
+                    <th className="stock-col">股票代碼/名稱</th>
                     <th>平均股價</th>
                     <th>總數量</th>
                     <th>操作</th>
@@ -327,7 +327,7 @@ export default function InventoryTab() {
                     ? <tr><td colSpan={4}>尚無庫存</td></tr>
                     : inventoryList.map((item, idx) => (
                         <tr key={idx}>
-                          <td>{item.stock_id} {item.stock_name || (stockList.find(s => s.stock_id === item.stock_id)?.stock_name || '')}</td>
+                          <td className="stock-col">{item.stock_id} {item.stock_name}</td>
                           <td>{item.avg_price.toFixed(2)}</td>
                           <td>{item.total_quantity} ({(item.total_quantity / 1000).toFixed(3).replace(/\.0+$/, '')} 張)</td>
                           <td>

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -201,7 +201,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
             <table className="table table-bordered table-striped">
                 <thead>
                     <tr>
-                        <th>
+                        <th className="stock-col">
                             <span className="sortable" onClick={() => handleSort('stock_id')}>
                                 股票代碼/名稱
                                 {sortConfig.column === 'stock_id' && (
@@ -237,7 +237,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     ) : (
                         sortedStocks.map(stock => (
                             <tr key={stock.stock_id + stock.stock_name}>
-                                <td>{stock.stock_id} {stock.stock_name}</td>
+                                <td className="stock-col">{stock.stock_id} {stock.stock_name}</td>
                                 {MONTHS.map((m, idx) => {
                                     const cell = dividendTable[stock.stock_id][idx];
                                     if (!cell || !cell.dividend || !cell.quantity) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}></td>;

--- a/src/components/AddTransactionModal.jsx
+++ b/src/components/AddTransactionModal.jsx
@@ -21,7 +21,14 @@ export default function AddTransactionModal({ show, onClose, stockList, form, se
               <Select
                 options={options}
                 value={selectedOption}
-                onChange={option => setForm(f => ({ ...f, stock_id: option ? option.value : '' }))}
+                onChange={option => {
+                  const stock = stockList.find(s => s.stock_id === (option ? option.value : ''));
+                  setForm(f => ({
+                    ...f,
+                    stock_id: option ? option.value : '',
+                    stock_name: stock ? stock.stock_name : ''
+                  }));
+                }}
                 placeholder="搜尋或選擇股票"
                 isClearable
               />

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -111,7 +111,7 @@ export default function StockTable({
 
     return (
       <tr>
-        <td>
+        <td className="stock-col">
           <a href={`/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
             {stock.stock_id} {stock.stock_name}
           </a>
@@ -158,7 +158,7 @@ export default function StockTable({
         <table className="table table-bordered table-striped">
           <thead>
             <tr>
-              <th>股票代碼/名稱</th>
+              <th className="stock-col">股票代碼/名稱</th>
               <th>最新股價</th>
               <th>股息總額</th>
               <th>當次殖利率</th>
@@ -184,7 +184,7 @@ export default function StockTable({
               const lastYield = latestYield[stock.stock_id]?.yield;
               return (
                 <tr key={stock.stock_id + stock.stock_name}>
-                  <td>
+                  <td className="stock-col">
                     <a href={`/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
                       {stock.stock_id} {stock.stock_name}
                     </a>
@@ -215,7 +215,7 @@ export default function StockTable({
       <table className="table table-bordered table-striped" style={{ minWidth: 1300 }}>
         <thead>
           <tr>
-            <th style={{ position: 'relative' }}>
+            <th className="stock-col">
               <span className="sortable" onClick={() => handleSort('stock_id')}>
                 股票代碼/名稱
                 <span className="sort-indicator">

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -6,7 +6,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
       <table className={`table table-bordered table-striped ${styles.table}`}>
         <thead>
           <tr>
-            <th>股票代碼/名稱</th>
+            <th className="stock-col">股票代碼/名稱</th>
             <th>交易日期</th>
             <th>數量(股)</th>
             <th>價格(元)</th>
@@ -21,9 +21,10 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
             transactionHistory.map((item, idx) => {
               const stock = stockList.find(s => s.stock_id === item.stock_id) || {};
               const isEditing = editingIdx === idx;
+              const name = item.stock_name || stock.stock_name || '';
               return (
                 <tr key={idx}>
-                  <td>{item.stock_id} {stock.stock_name || ''}</td>
+                  <td className="stock-col">{item.stock_id} {name}</td>
                   <td>
                     {isEditing ? (
                       <input


### PR DESCRIPTION
## Summary
- ensure first column header in ETF dividend table remains sticky
- persist and display stock names in inventory and history records
- give stock code/name columns a consistent width and rewrite about page copy

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba757ad7708329a358c7cd5a969d22