### PR TITLE
feat: add light/dark theme toggle with persistent preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
@@ -9,6 +9,12 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css"
     />
+    <script>
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme) {
+        document.documentElement.setAttribute('data-theme', savedTheme);
+      }
+    </script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     <title>Dividend Life</title>
   </head>

--- a/src/App.css
+++ b/src/App.css
@@ -35,7 +35,7 @@
 
 .card {
   padding: 2em;
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 0.5rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -49,9 +49,9 @@
 }
 
 .dividend-alert {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  color: #1f2937;
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
   padding: 8px;
   border-radius: 4px;
   margin-bottom: 12px;
@@ -68,11 +68,11 @@ tbody tr {
 }
 
 tbody tr:nth-child(even) {
-  background-color: #f3f4f6;
+  background-color: var(--color-row-even);
 }
 
 tbody tr:hover {
-  background-color: #e5e7eb;
+  background-color: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -86,7 +86,7 @@ td {
 }
 
 .current-month {
-  background: #e5e7eb;
+  background: var(--color-hover);
 }
 
 .crown-icon {
@@ -112,7 +112,7 @@ td {
   margin-left: 6px;
   cursor: pointer;
   font-size: 14px;
-  color: #d4af37;
+  color: var(--accent-gold);
   vertical-align: middle;
   user-select: none;
   border-radius: 3px;
@@ -128,15 +128,15 @@ td {
   z-index: 99;
   top: 30px;
   left: 0;
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.1);
   padding: 12px 14px 8px 14px;
   border-radius: 8px;
   min-width: 140px;
   min-height: 40px;
   text-align: left;
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .dropdown label {
@@ -157,20 +157,20 @@ td {
   font-size: 12px;
   padding: 2px 10px;
   border-radius: 6px;
-  border: 1px solid #e5e7eb;
-  background: #fff;
-  color: #1f2937;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-bg);
+  color: var(--color-text);
   margin-left: 0;
   cursor: pointer;
 }
 .dropdown-btn:hover {
-  background: #f3f4f6;
+  background: var(--color-row-even);
 }
 
 .dropdown hr {
   margin: 6px 0;
   border: none;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--color-border);
 }
 
 /* Action dropdown for top controls */
@@ -179,8 +179,8 @@ td {
   z-index: 99;
   top: 36px;
   right: 0;
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.1);
   padding: 10px;
   border-radius: 8px;
@@ -191,29 +191,29 @@ td {
   display: block;
   width: 100%;
   margin: 4px 0;
-  background: #fff;
-  color: #1f2937;
-  border: 1px solid #e5e7eb;
+  background: var(--color-card-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
   font-size: 14px;
   text-align: left;
 }
 
 .action-dropdown button:hover {
-  background: #f3f4f6;
+  background: var(--color-row-even);
 }
 
 .slogan {
   font-size: 1.4rem;
   margin-top: 0;
   margin-bottom: 5px;
-  color: #d4af37;
+  color: var(--accent-gold);
   font-style: italic;
   font-weight: 300;
 }
 
 table thead {
-  background: #f3f4f6;
-  color: #1f2937;
+  background: var(--color-header-bg);
+  color: var(--color-text);
 }
 
 .site-title {
@@ -221,7 +221,7 @@ table thead {
   font-weight: 600;
   text-align: center;
   margin-bottom: 8px;
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .contact-section,
@@ -231,10 +231,10 @@ table thead {
 }
 
 header {
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--color-border);
   margin-bottom: 1rem;
   padding: 20px 0;
-  background: #fff;
+  background: var(--color-card-bg);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.3s;
   border-radius: 12px;
@@ -246,11 +246,11 @@ header:hover {
 
 .contact-section a,
 .donation-section a {
-  color: #d4af37;
+  color: var(--accent-gold);
 }
 
 button {
-  background: #d4af37;
+  background: var(--accent-gold);
   color: #000;
   border: none;
   border-radius: 6px;
@@ -262,7 +262,7 @@ button {
 
 button:hover,
 button:focus {
-  background: #ffd700;
+  background: var(--accent-gold-hover);
   color: #000;
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(255, 215, 0, 0.3);
@@ -310,12 +310,12 @@ button:active {
 }
 .calendar-grid th,
 .calendar-grid td {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   width: 14.28%;
   height: 100px;
   vertical-align: top;
   position: relative;
-  background: #f5f5f5;
+  background: var(--color-card-bg);
 }
 
 .calendar-today {
@@ -334,7 +334,7 @@ button:active {
   position: absolute;
   top: 4px;
   right: 4px;
-  color: #555;
+  color: var(--color-text);
   font-size: 14px;
 }
 .event {
@@ -408,7 +408,7 @@ button:active {
 .table-responsive thead th {
   position: sticky;
   top: 0;
-  background: #fff;
+  background: var(--color-card-bg);
   z-index: 1;
 }
 
@@ -416,7 +416,7 @@ button:active {
 .table-responsive table td:first-child {
   position: sticky;
   left: 0;
-  background: #fff;
+  background: var(--color-card-bg);
   z-index: 2;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,16 @@ function App() {
   const [showDisplays, setShowDisplays] = useState(false);
   const [showAllStocks, setShowAllStocks] = useState(false);
 
+  // Theme
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark');
+
   const [editingGroupIndex, setEditingGroupIndex] = useState(null);
   const [groupNameInput, setGroupNameInput] = useState('');
   const [groupIdsInput, setGroupIdsInput] = useState('');
@@ -541,6 +551,8 @@ function App() {
                     showDividendYield={showDividendYield}
                     toggleAxis={() => setShowInfoAxis(v => !v)}
                     showInfoAxis={showInfoAxis}
+                    toggleTheme={toggleTheme}
+                    theme={theme}
                     onClose={() => setShowDisplays(false)}
                   />
                 )}

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -8,6 +8,10 @@ jest.mock('./api');
 jest.mock('./config', () => ({
   API_HOST: 'http://localhost'
 }));
+jest.mock('./driveSync', () => ({
+  exportToDrive: jest.fn(),
+  importFromDrive: jest.fn()
+}));
 
 describe('InventoryTab interactions', () => {
   beforeEach(() => {

--- a/src/components/DisplayDropdown.jsx
+++ b/src/components/DisplayDropdown.jsx
@@ -10,6 +10,8 @@ export default function DisplayDropdown({
   showDividendYield,
   toggleAxis,
   showInfoAxis,
+  toggleTheme,
+  theme,
   onClose
 }) {
   const ref = useRef();
@@ -38,6 +40,9 @@ export default function DisplayDropdown({
           </button>
         </>
       )}
+      <button onClick={() => handleClick(toggleTheme)}>
+        {theme === 'dark' ? '切換為亮色主題' : '切換為暗色主題'}
+      </button>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,36 @@
 :root {
+  --color-text: #1f2937;
+  --color-bg: #f9fafb;
+  --color-card-bg: #fff;
+  --color-border: #e5e7eb;
+  --color-row-even: #f3f4f6;
+  --color-hover: #e5e7eb;
+  --color-header-bg: #f3f4f6;
+  --accent-gold: #d4af37;
+  --accent-gold-hover: #ffd700;
+  --accent-green: #2f9e44;
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color: #1f2937;
-  background-color: #f9fafb;
+  color: var(--color-text);
+  background-color: var(--color-bg);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme='dark'] {
+  --color-text: #f9fafb;
+  --color-bg: #111827;
+  --color-card-bg: #1f2937;
+  --color-border: #374151;
+  --color-row-even: #1f2937;
+  --color-hover: #374151;
+  --color-header-bg: #374151;
 }
 
 html {
@@ -18,11 +39,11 @@ html {
 
 a {
   font-weight: 500;
-  color: #d4af37;
+  color: var(--accent-gold);
   text-decoration: inherit;
 }
 a:hover {
-  color: #ffd700;
+  color: var(--accent-gold-hover);
 }
 body {
   margin: 0;
@@ -30,8 +51,8 @@ body {
   min-width: 320px;
   min-height: 100vh;
   animation: fade-in 0.4s ease-in-out;
-  background-color: #f9fafb;
-  color: #1f2937;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 


### PR DESCRIPTION
## Summary
- add light and dark themes with shared gold/green accents
- allow toggling theme from "更多顯示" and remember user choice
- update tests to mock Drive sync module

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb734951dc83298baa38356eb68168