### PR TITLE
Update dark theme styling and stock links

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -61,6 +61,13 @@ table {
   width: 100%;
   margin-top: 20px;
   overflow: visible !important;
+  --bs-table-bg: var(--color-card-bg);
+  --bs-table-striped-bg: var(--color-row-even);
+  --bs-table-striped-color: var(--color-text);
+  --bs-table-hover-bg: var(--color-hover);
+  --bs-table-hover-color: var(--color-text);
+  --bs-table-color: var(--color-text);
+  --bs-table-border-color: var(--color-border);
 }
 
 tbody tr {
@@ -251,7 +258,7 @@ header:hover {
 
 button {
   background: var(--accent-gold);
-  color: #000;
+  color: var(--color-text);
   border: none;
   border-radius: 6px;
   font-weight: 500;
@@ -263,7 +270,7 @@ button {
 button:hover,
 button:focus {
   background: var(--accent-gold-hover);
-  color: #000;
+  color: var(--color-text);
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(255, 215, 0, 0.3);
 }
@@ -439,10 +446,10 @@ button:active {
 /* Stock detail page */
 .stock-detail {
   padding: 20px;
-  background: #222;
+  background: var(--color-card-bg);
   border-radius: 8px;
   line-height: 1.6;
-  color: #f5f5f5;
+  color: var(--color-text);
 }
 
 .stock-detail h1 {
@@ -459,7 +466,7 @@ button:active {
 }
 
 .stock-detail .link-list a {
-  color: #d4af37;
+  color: var(--accent-gold);
 }
 
 .stock-detail .link-list a:hover {
@@ -469,7 +476,8 @@ button:active {
 .stock-detail .disclaimer {
   margin-top: 8px;
   font-size: 13px;
-  color: #bbb;
+  color: var(--color-text);
+  opacity: 0.8;
 }
 
 /* Modal */

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -329,7 +329,11 @@ export default function InventoryTab() {
                     ? <tr><td colSpan={4}>尚無庫存</td></tr>
                     : inventoryList.map((item, idx) => (
                         <tr key={idx}>
-                          <td className="stock-col">{item.stock_id} {item.stock_name}</td>
+                          <td className="stock-col">
+                            <a href={`https://etflife.org/stock/${item.stock_id}`} target="_blank" rel="noreferrer">
+                              {item.stock_id} {item.stock_name}
+                            </a>
+                          </td>
                           <td>{item.avg_price.toFixed(2)}</td>
                           <td>{item.total_quantity} ({(item.total_quantity / 1000).toFixed(3).replace(/\.0+$/, '')} 張)</td>
                           <td>

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -52,6 +52,6 @@
 }
 
 .sellButton {
-  min-width: 48px;
+  width: 60px;
   white-space: nowrap;
 }

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
 import { API_HOST } from './config';
 import { fetchWithCache } from './api';
+import './App.css';
 
 export default function StockDetail({ stockId }) {
   const [stock, setStock] = useState(null);
   const [dividends, setDividends] = useState([]);
   const [stockCacheInfo, setStockCacheInfo] = useState(null);
-  const [dividendCacheInfo, setDividendCacheInfo] = useState(null);
 
   // fetch stock basic info
   useEffect(() => {
@@ -23,12 +23,11 @@ export default function StockDetail({ stockId }) {
   // fetch dividend records
   useEffect(() => {
     fetchWithCache(`${API_HOST}/get_dividend`)
-      .then(({ data, cacheStatus, timestamp }) => {
+      .then(({ data }) => {
         const list = Array.isArray(data) ? data : data?.items || [];
         const arr = list.filter(item => item.stock_id === stockId);
         arr.sort((a, b) => new Date(b.dividend_date) - new Date(a.dividend_date));
         setDividends(arr);
-        setDividendCacheInfo({ cacheStatus, timestamp });
       })
       .catch(() => setDividends([]));
   }, [stockId]);
@@ -50,14 +49,8 @@ export default function StockDetail({ stockId }) {
       <h1>{stock.stock_id} {stock.stock_name}</h1>
       {stockCacheInfo && (
         <div style={{ textAlign: 'right', fontSize: 12 }}>
-          基本資料快取: {stockCacheInfo.cacheStatus}
+          資料快取: {stockCacheInfo.cacheStatus}
           {stockCacheInfo.timestamp ? ` (${new Date(stockCacheInfo.timestamp).toLocaleString()})` : ''}
-        </div>
-      )}
-      {dividendCacheInfo && (
-        <div style={{ textAlign: 'right', fontSize: 12 }}>
-          配息資料快取: {dividendCacheInfo.cacheStatus}
-          {dividendCacheInfo.timestamp ? ` (${new Date(dividendCacheInfo.timestamp).toLocaleString()})` : ''}
         </div>
       )}
       <p>配息頻率: {stock.dividend_frequency || '-'}</p>
@@ -65,7 +58,7 @@ export default function StockDetail({ stockId }) {
       <p>發行券商: {issuer || '-'}</p>
       <p>
         官網: {website ? (
-          <a href={website} target="_blank" rel="noreferrer">{website}</a>
+          <a href={website} target="_blank" rel="noreferrer" style={{ wordBreak: 'break-all' }}>{website}</a>
         ) : (
           '-'
         )}

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -237,7 +237,11 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     ) : (
                         sortedStocks.map(stock => (
                             <tr key={stock.stock_id + stock.stock_name}>
-                                <td className="stock-col">{stock.stock_id} {stock.stock_name}</td>
+                                <td className="stock-col">
+                                    <a href={`https://etflife.org/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
+                                        {stock.stock_id} {stock.stock_name}
+                                    </a>
+                                </td>
                                 {MONTHS.map((m, idx) => {
                                     const cell = dividendTable[stock.stock_id][idx];
                                     if (!cell || !cell.dividend || !cell.quantity) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}></td>;

--- a/src/components/AddTransactionModal.module.css
+++ b/src/components/AddTransactionModal.module.css
@@ -13,12 +13,12 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  background: #000;
+  background: var(--color-card-bg);
   border-radius: 10px;
   padding: 28px;
   min-width: 400px;
   box-shadow: 0 4px 18px #0008;
-  color: #fff;
+  color: var(--color-text);
 }
 
 .title {
@@ -57,10 +57,10 @@
   width: 100%;
   height: 30px;
   border-radius: 5px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   padding-left: 6px;
-  background: #fff;
-  color: #000;
+  background: var(--color-card-bg);
+  color: var(--color-text);
 }
 
 .buttonRow {
@@ -83,9 +83,9 @@
 
 .secondaryButton {
   padding: 7px 22px;
-  background: #eee;
-  color: #555;
-  border: 1px solid #bbb;
+  background: var(--color-row-even);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   cursor: pointer;
 }

--- a/src/components/SellModal.module.css
+++ b/src/components/SellModal.module.css
@@ -13,12 +13,12 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  background: #000;
+  background: var(--color-card-bg);
   border-radius: 10px;
   padding: 28px;
   min-width: 350px;
   box-shadow: 0 4px 18px #0008;
-  color: #fff;
+  color: var(--color-text);
 }
 
 .title {
@@ -47,10 +47,10 @@
   width: 100%;
   height: 30px;
   border-radius: 5px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   padding-left: 6px;
-  background: #fff;
-  color: #000;
+  background: var(--color-card-bg);
+  color: var(--color-text);
 }
 
 .text {
@@ -77,9 +77,9 @@
 
 .secondaryButton {
   padding: 7px 22px;
-  background: #eee;
-  color: #555;
-  border: 1px solid #bbb;
+  background: var(--color-row-even);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   cursor: pointer;
 }

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -112,7 +112,7 @@ export default function StockTable({
     return (
       <tr>
         <td className="stock-col">
-          <a href={`/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
+          <a href={`https://etflife.org/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
             {stock.stock_id} {stock.stock_name}
           </a>
         </td>
@@ -185,7 +185,7 @@ export default function StockTable({
               return (
                 <tr key={stock.stock_id + stock.stock_name}>
                   <td className="stock-col">
-                    <a href={`/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
+                    <a href={`https://etflife.org/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
                       {stock.stock_id} {stock.stock_name}
                     </a>
                   </td>

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -24,7 +24,11 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
               const name = item.stock_name || stock.stock_name || '';
               return (
                 <tr key={idx}>
-                  <td className="stock-col">{item.stock_id} {name}</td>
+                  <td className="stock-col">
+                    <a href={`https://etflife.org/stock/${item.stock_id}`} target="_blank" rel="noreferrer">
+                      {item.stock_id} {name}
+                    </a>
+                  </td>
                   <td>
                     {isEditing ? (
                       <input
@@ -71,29 +75,31 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
                   </td>
                   <td>{item.type === 'sell' ? '賣出' : '買入'}</td>
                   <td className={styles.operationCol}>
-                    {isEditing ? (
-                      <>
-                        <button onClick={() => handleEditSave(idx)}>儲存</button>
-                        <button onClick={() => setEditingIdx(null)} className={styles.actionButton}>取消</button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          onClick={() => {
-                            setEditingIdx(idx);
-                            setEditForm({ date: item.date, quantity: item.quantity, price: item.price });
-                          }}
-                        >
-                          修改
-                        </button>
-                        <button
-                          onClick={() => handleDelete(idx)}
-                          className={styles.actionButton}
-                        >
-                          刪除
-                        </button>
-                      </>
-                    )}
+                    <div className={styles.actions}>
+                      {isEditing ? (
+                        <>
+                          <button onClick={() => handleEditSave(idx)}>儲存</button>
+                          <button onClick={() => setEditingIdx(null)} className={styles.actionButton}>取消</button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => {
+                              setEditingIdx(idx);
+                              setEditForm({ date: item.date, quantity: item.quantity, price: item.price });
+                            }}
+                          >
+                            修改
+                          </button>
+                          <button
+                            onClick={() => handleDelete(idx)}
+                            className={styles.actionButton}
+                          >
+                            刪除
+                          </button>
+                        </>
+                      )}
+                    </div>
                   </td>
                 </tr>
               );

--- a/src/components/TransactionHistoryTable.module.css
+++ b/src/components/TransactionHistoryTable.module.css
@@ -3,7 +3,7 @@
 }
 
 .operationCol {
-  width: 160px;
+  width: 140px;
 }
 
 .smallInput {
@@ -14,9 +14,13 @@
   margin-left: 6px;
 }
 
-@media (max-width: 600px) {
-  .operationCol button {
-    width: 2em;
-    padding: 2px;
-  }
+.actions {
+  display: flex;
+  gap: 6px;
+}
+
+.operationCol button {
+  width: 60px;
+  padding: 2px;
+  white-space: nowrap;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,17 @@
   --accent-gold-hover: #ffd700;
   --accent-green: #2f9e44;
 
+  /* Bootstrap color variables */
+  --bs-body-color: var(--color-text);
+  --bs-body-bg: var(--color-bg);
+  --bs-table-bg: var(--color-card-bg);
+  --bs-table-striped-bg: var(--color-row-even);
+  --bs-table-striped-color: var(--color-text);
+  --bs-table-hover-bg: var(--color-hover);
+  --bs-table-hover-color: var(--color-text);
+  --bs-table-color: var(--color-text);
+  --bs-table-border-color: var(--color-border);
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;


### PR DESCRIPTION
## Summary
- refine dark-mode colors for tables and buttons
- link all stock codes to external ETF detail pages
- sync ETF detail page theme and metadata wording
- normalize inventory action buttons for mobile layout

## Testing
- `pnpm lint` *(fails: 'selectStyles' is not defined, 'process' is defined but never used, 'CLIENT_ID' and 'SCOPE' are constant)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7770b3ac8329932be8faef985b90