### PR TITLE
Improve dark theme and unify button styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -164,14 +164,14 @@ td {
   font-size: 12px;
   padding: 2px 10px;
   border-radius: 6px;
-  border: 1px solid var(--color-border);
-  background: var(--color-card-bg);
+  background: var(--accent-gold);
   color: var(--color-text);
+  border: none;
   margin-left: 0;
   cursor: pointer;
 }
 .dropdown-btn:hover {
-  background: var(--color-row-even);
+  background: var(--accent-gold-hover);
 }
 
 .dropdown hr {
@@ -235,6 +235,12 @@ table thead {
 .donation-section {
   margin-top: 40px;
   text-align: center;
+}
+
+.contact-wrapper {
+  background: var(--color-card-bg);
+  padding: 12px 16px;
+  border-radius: 8px;
 }
 
 header {
@@ -540,10 +546,10 @@ button:active {
   z-index: 1001;
   width: 40px;
   height: 40px;
-  background: #1a1a1a;
-  border: 1px solid #444;
+  background: var(--accent-gold);
+  border: none;
   border-radius: 50%;
-  color: #d4af37;
+  color: var(--color-text);
   cursor: pointer;
 }
 
@@ -561,10 +567,10 @@ button:active {
 .nl-helper button {
   margin-bottom: 8px;
   padding: 6px;
-  background: #333;
-  border: 1px solid #555;
+  background: var(--accent-gold);
+  border: none;
   border-radius: 4px;
-  color: #d4af37;
+  color: var(--color-text);
   cursor: pointer;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -639,7 +639,7 @@ function App() {
         />
       }
       {tab === 'about' && <AboutTab />}
-      <div style={{ backgroundColor: '#f5f5f5', padding: '12px 16px', borderRadius: 8 }}>
+      <div className="contact-wrapper">
         <div className="contact-section">
           <h3>聯絡方式</h3>
           <p>電子信箱：<a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a></p>

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -31,8 +31,9 @@
 .button {
   padding: 6px 18px;
   border-radius: 6px;
-  border: 1px solid #888;
-  background: #e7f0fd;
+  background: var(--accent-gold);
+  border: none;
+  color: var(--color-text);
   cursor: pointer;
 }
 

--- a/src/components/AddTransactionModal.module.css
+++ b/src/components/AddTransactionModal.module.css
@@ -72,8 +72,8 @@
 
 .primaryButton {
   padding: 7px 26px;
-  background: #1e70b8;
-  color: #fff;
+  background: var(--accent-gold);
+  color: var(--color-text);
   border: none;
   border-radius: 6px;
   font-weight: 600;

--- a/src/components/SellModal.module.css
+++ b/src/components/SellModal.module.css
@@ -66,8 +66,8 @@
 
 .primaryButton {
   padding: 7px 26px;
-  background: #1e70b8;
-  color: #fff;
+  background: var(--accent-gold);
+  color: var(--color-text);
   border: none;
   border-radius: 6px;
   font-weight: 600;

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,11 @@
   --bs-table-hover-color: var(--color-text);
   --bs-table-color: var(--color-text);
   --bs-table-border-color: var(--color-border);
+  --bs-nav-link-color: var(--color-text);
+  --bs-nav-link-hover-color: var(--color-text);
+  --bs-nav-tabs-link-active-color: var(--color-text);
+  --bs-nav-tabs-link-active-bg: var(--color-bg);
+  --bs-nav-tabs-link-active-border-color: var(--color-border);
 
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- ensure nav tab text stays readable in dark mode
- make contact and donation section background theme-aware
- unify button styling across modals, dropdowns and helper tools

## Testing
- `pnpm lint` *(fails: 'selectStyles' is not defined; 'process' is defined but never used; 'CLIENT_ID' is constant; 'SCOPE' is constant)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbad0476a48329975cb4288cae350e