### PR TITLE
Fix add transaction modal and add test

### DIFF
--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -20,6 +20,13 @@ describe('InventoryTab interactions', () => {
     fetchWithCache.mockResolvedValue({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
   });
 
+  test('opens add transaction modal', async () => {
+    render(<InventoryTab />);
+    const openBtn = screen.getByRole('button', { name: '新增購買紀錄' });
+    fireEvent.click(openBtn);
+    await screen.findByRole('heading', { name: '新增購買紀錄' });
+  });
+
   test('edits existing transaction', async () => {
     localStorage.setItem('my_transaction_history', JSON.stringify([
       { stock_id: '0050', date: '2024-01-01', quantity: 1000, type: 'buy', price: 10 }

--- a/src/components/AddTransactionModal.jsx
+++ b/src/components/AddTransactionModal.jsx
@@ -1,6 +1,34 @@
 import Select from 'react-select';
 import styles from './AddTransactionModal.module.css';
 
+const selectStyles = {
+  control: provided => ({
+    ...provided,
+    backgroundColor: 'var(--color-card-bg)',
+    borderColor: 'var(--color-border)',
+    color: 'var(--color-text)'
+  }),
+  input: provided => ({
+    ...provided,
+    color: 'var(--color-text)'
+  }),
+  singleValue: provided => ({
+    ...provided,
+    color: 'var(--color-text)'
+  }),
+  menu: provided => ({
+    ...provided,
+    backgroundColor: 'var(--color-card-bg)',
+    color: 'var(--color-text)',
+    zIndex: 1100
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    backgroundColor: state.isFocused ? 'var(--color-row-even)' : 'var(--color-card-bg)',
+    color: 'var(--color-text)'
+  })
+};
+
 export default function AddTransactionModal({ show, onClose, stockList, form, setForm, onSubmit }) {
   if (!show) return null;
   const options = stockList.map(s => ({


### PR DESCRIPTION
## Summary
- define `selectStyles` in `AddTransactionModal` to avoid runtime error when opening modal
- add regression test verifying the add transaction modal opens on click

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 'process' is defined but never used, 'CLIENT_ID' is constant, 'SCOPE' is constant in src/driveSync.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbecc07448329a84ca813022ab7fc