### PR TITLE
Set My Dividends as default tab and fix dark theme active color

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,7 +41,7 @@ function getIncomeGoalInfo(dividend, price, goal, freq = 12) {
 
 function App() {
   // Tab state
-  const [tab, setTab] = useState('dividend');
+  const [tab, setTab] = useState('mydividend');
 
   // All your existing states for dividend page...
   const [data, setData] = useState([]);
@@ -469,6 +469,14 @@ function App() {
       <ul className="nav nav-tabs mb-1 justify-content-center">
         <li className="nav-item">
           <button
+            className={`nav-link${tab === 'mydividend' ? ' active' : ''}`}
+            onClick={() => setTab('mydividend')}
+          >
+            我的配息
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
             className={`nav-link${tab === 'dividend' ? ' active' : ''}`}
             onClick={() => setTab('dividend')}
           >
@@ -481,14 +489,6 @@ function App() {
             onClick={() => setTab('inventory')}
           >
             庫存管理
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
-            className={`nav-link${tab === 'mydividend' ? ' active' : ''}`}
-            onClick={() => setTab('mydividend')}
-          >
-            我的配息
           </button>
         </li>
         <li className="nav-item">

--- a/src/driveSync.js
+++ b/src/driveSync.js
@@ -1,6 +1,6 @@
-/* global google, process */
-const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-const SCOPE = import.meta.env.VITE_GOOGLE_SCOPE;
+/* global google */
+let CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+let SCOPE = import.meta.env.VITE_GOOGLE_SCOPE;
 try {
   const env = new Function('return import.meta.env')();
   CLIENT_ID = env.VITE_GOOGLE_CLIENT_ID;

--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,10 @@
   --color-header-bg: #374151;
 }
 
+[data-theme='dark'] .nav-tabs .nav-link.active {
+  color: #fff;
+}
+
 html {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- Make "My Dividends" the first and default tab in navigation
- Show active tab text in white under dark theme
- Resolve linter issues in Google Drive sync utility

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbc163da7c8329999dac9dddb1a0a6