### PR TITLE
Show total investment above inventory table

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -173,6 +173,8 @@ export default function InventoryTab() {
     .filter(i => i.total_quantity > 0)
     .map(i => ({ ...i, avg_price: i.total_cost / i.total_quantity }));
 
+  const totalInvestment = inventoryList.reduce((sum, item) => sum + item.total_cost, 0);
+
   const handleAdd = () => {
     if (!form.stock_id || !form.date || !form.quantity || !form.price) {
       alert('請輸入完整資料');
@@ -312,6 +314,10 @@ export default function InventoryTab() {
                 {cacheInfo.timestamp ? ` (${new Date(cacheInfo.timestamp).toLocaleString()})` : ''}
               </div>
             )}
+
+            <div className={styles.totalInvestment}>
+              目前總投資金額：{totalInvestment.toFixed(2)}
+            </div>
 
             <div className="table-responsive">
               <table className={`table table-bordered table-striped ${styles.fullWidth}`}>

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -56,3 +56,9 @@
   width: 60px;
   white-space: nowrap;
 }
+
+.totalInvestment {
+  text-align: right;
+  font-weight: bold;
+  margin: 4px 0;
+}

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -27,6 +27,15 @@ describe('InventoryTab interactions', () => {
     await screen.findByRole('heading', { name: '新增購買紀錄' });
   });
 
+  test('displays total investment amount', async () => {
+    localStorage.setItem('my_transaction_history', JSON.stringify([
+      { stock_id: '0050', date: '2024-01-01', quantity: 1000, type: 'buy', price: 10 }
+    ]));
+    render(<InventoryTab />);
+    await waitFor(() => screen.getByText('顯示：交易歷史'));
+    expect(screen.getByText('目前總投資金額：10000.00')).toBeInTheDocument();
+  });
+
   test('edits existing transaction', async () => {
     localStorage.setItem('my_transaction_history', JSON.stringify([
       { stock_id: '0050', date: '2024-01-01', quantity: 1000, type: 'buy', price: 10 }


### PR DESCRIPTION
## Summary
- compute total investment from inventory data
- display total investment amount above inventory table with styles
- test that total investment is rendered

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc60c6ce883298d8a4d0e46de298b