### PR TITLE
feat: add usage guide tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import InventoryTab from './InventoryTab';
 import UserDividendsTab from './UserDividendsTab';
 import AboutTab from './AboutTab';
 import DisclaimerTab from './DisclaimerTab';
+import GuideTab from './GuideTab';
 import ActionDropdown from './components/ActionDropdown';
 import DisplayDropdown from './components/DisplayDropdown';
 import DividendCalendar from './components/DividendCalendar';
@@ -494,6 +495,14 @@ function App() {
         </li>
         <li className="nav-item">
           <button
+            className={`nav-link${tab === 'guide' ? ' active' : ''}`}
+            onClick={() => setTab('guide')}
+          >
+            使用說明
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
             className={`nav-link${tab === 'about' ? ' active' : ''}`}
             onClick={() => setTab('about')}
           >
@@ -647,6 +656,7 @@ function App() {
           selectedYear={selectedYear}
         />
       }
+      {tab === 'guide' && <GuideTab />}
       {tab === 'about' && <AboutTab />}
       {tab === 'disclaimer' && <DisclaimerTab />}
       <div className="contact-wrapper">

--- a/src/GuideTab.jsx
+++ b/src/GuideTab.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+export default function GuideTab() {
+  return (
+    <div className="container" style={{ maxWidth: 800 }}>
+      <h1 className="mt-4">使用小幫手</h1>
+      <p>
+        以下以「公開資訊瀏覽」與「個人股息紀錄」兩大區塊說明，先玩玩現有功能，未來有新工具再慢慢上線囉。
+      </p>
+      <h2>A. 瀏覽 ETF 與配息資訊</h2>
+      <ol>
+        <li>
+          <strong>搜尋與篩選</strong>
+          <br />
+          在首頁或清單頁輸入代號／名稱，搭配篩選器（市場、配息頻率、殖利率區間、規模、主題等）就能迅速縮小範圍。
+        </li>
+        <li>
+          <strong>ETF 詳細頁</strong>
+          <br />
+          可查看配息歷史（公告日、除息日、發放日、每單位配息）、殖利率指標（如 TTM/年度預估）、基本資料（成立日、規模、管理費／保管費）與走勢圖。
+        </li>
+        <li>
+          <strong>自選清單（如有）</strong>
+          <br />
+          於清單或詳細頁點「加入自選」，在「自選」頁即可追蹤關注標的並接收即將除息／發放的小提醒（若有通知功能）。
+        </li>
+      </ol>
+      <h2>B. 紀錄個人股息（投資組合）</h2>
+      <ol>
+        <li>
+          <strong>建立投資組合</strong>
+          <br />
+          在「投資組合」點「新增」，幫它取個名字（例如：長線、退休帳戶），再選擇幣別與可見性（只有自己看得到）。
+        </li>
+        <li>
+          <strong>新增持有與配息紀錄</strong>
+          <br />
+          「新增交易」：填入日期、代號、數量、單價、手續費／稅。
+          <br />
+          「新增配息」：填入發放日、代號、每單位配息、持有數量（或自動帶入）、稅費、實際入帳金額；也可勾選「配息再投資」並填入成交資訊。
+        </li>
+        <li>
+          <strong>匯入 CSV（可選）</strong>
+          <br />
+          下載範本，上傳符合欄位的 CSV，就能快速導入歷史資料。
+          <br />
+          建議欄位：date,ticker,market,action,qty,price,fee,tax,cash_dividend,stock_dividend,currency,fx_rate,note
+        </li>
+        <li>
+          <strong>統計與圖表</strong>
+          <br />
+          在「統計」頁查看月／季／年股息、累計現金流、依標的／產業／幣別分佈、殖利率走勢（如有）。
+        </li>
+        <li>
+          <strong>通知與匯出（如有）</strong>
+          <br />
+          開啟 Email/推播提醒，在除息前或發放日前先收到通知。資料也能匯出成 CSV 做備份或試算。
+        </li>
+      </ol>
+      <p>
+        小技巧：若你持有多個券商帳戶，可用「標籤/備註」欄位區分，報表就能按標籤彙總，管理起來更清楚。
+      </p>
+    </div>
+  );
+}

--- a/src/GuideTab.test.jsx
+++ b/src/GuideTab.test.jsx
@@ -1,0 +1,10 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import GuideTab from './GuideTab';
+
+test('renders guide heading', () => {
+  render(<GuideTab />);
+  expect(
+    screen.getByRole('heading', { name: /使用小幫手/ })
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add a friendly usage guide tab to explain browsing ETF info and tracking dividends
- link the new tab into navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbff93feac8329bb630b7584101304