### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import InventoryTab from './InventoryTab';
 import UserDividendsTab from './UserDividendsTab';
 import AboutTab from './AboutTab';
 import DisclaimerTab from './DisclaimerTab';
+import PrivacyPolicyTab from './PrivacyPolicyTab';
+import TermsOfServiceTab from './TermsOfServiceTab';
 import GuideTab from './GuideTab';
 import FaqTab from './FaqTab';
 import ActionDropdown from './components/ActionDropdown';
@@ -526,6 +528,22 @@ function App() {
             免責聲明
           </button>
         </li>
+        <li className="nav-item">
+          <button
+            className={`nav-link${tab === 'terms' ? ' active' : ''}`}
+            onClick={() => setTab('terms')}
+          >
+            服務條款
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
+            className={`nav-link${tab === 'privacy' ? ' active' : ''}`}
+            onClick={() => setTab('privacy')}
+          >
+            隱私權政策
+          </button>
+        </li>
       </ul>
       {tab === 'dividend' && (
         <div className="App">
@@ -669,6 +687,8 @@ function App() {
       {tab === 'faq' && <FaqTab />}
       {tab === 'about' && <AboutTab />}
       {tab === 'disclaimer' && <DisclaimerTab />}
+      {tab === 'terms' && <TermsOfServiceTab />}
+      {tab === 'privacy' && <PrivacyPolicyTab />}
       <div className="contact-wrapper">
         <div className="contact-section">
           <h3>聯絡方式</h3>

--- a/src/PrivacyPolicyTab.jsx
+++ b/src/PrivacyPolicyTab.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function PrivacyPolicyTab() {
+  return (
+    <div className="container" style={{ maxWidth: 800 }}>
+      <h1 className="mt-4">隱私權政策</h1>
+      <p>
+        本站尊重並保護您的個人資料，僅蒐集提供服務所必需的資訊。您可隨時查詢、下載、
+        更正或刪除自己的資料，詳細內容請參考本政策。
+      </p>
+    </div>
+  );
+}

--- a/src/PrivacyPolicyTab.test.jsx
+++ b/src/PrivacyPolicyTab.test.jsx
@@ -1,0 +1,10 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import PrivacyPolicyTab from './PrivacyPolicyTab';
+
+test('renders privacy policy heading', () => {
+  render(<PrivacyPolicyTab />);
+  expect(
+    screen.getByRole('heading', { name: /隱私權政策/ })
+  ).toBeInTheDocument();
+});

--- a/src/TermsOfServiceTab.jsx
+++ b/src/TermsOfServiceTab.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function TermsOfServiceTab() {
+  return (
+    <div className="container" style={{ maxWidth: 800 }}>
+      <h1 className="mt-4">服務條款</h1>
+      <p>
+        使用本服務即表示您同意遵守本站規範，包含使用者義務、智慧財產權與責任限制等。
+        任何爭議將依相關法律處理。
+      </p>
+    </div>
+  );
+}

--- a/src/TermsOfServiceTab.test.jsx
+++ b/src/TermsOfServiceTab.test.jsx
@@ -1,0 +1,10 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import TermsOfServiceTab from './TermsOfServiceTab';
+
+test('renders terms heading', () => {
+  render(<TermsOfServiceTab />);
+  expect(
+    screen.getByRole('heading', { name: /服務條款/ })
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add dedicated tabs for privacy policy and terms of service
- link new pages in navigation and render logic
- cover new components with simple tests

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0d70e53c8329b03feb7857b4a4de