### PR TITLE
Consolidate site info into About tab

### DIFF
--- a/src/AboutTab.jsx
+++ b/src/AboutTab.jsx
@@ -1,15 +1,27 @@
 import React from 'react';
+import GuideTab from './GuideTab';
+import FaqTab from './FaqTab';
+import DisclaimerTab from './DisclaimerTab';
+import TermsOfServiceTab from './TermsOfServiceTab';
+import PrivacyPolicyTab from './PrivacyPolicyTab';
 
 export default function AboutTab() {
   return (
-    <div className="container" style={{ maxWidth: 800 }}>
-      <h1 className="mt-4">關於本站</h1>
-      <p>
-        這裡是個幫你整理 ETF 配息的小天地，也附上簡單的持股追蹤工具。資料僅供參考，不構成投資建議唷！
-      </p>
-      <p>
-        這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～
-      </p>
-    </div>
+    <>
+      <div className="container" style={{ maxWidth: 800 }}>
+        <h1 className="mt-4">關於本站</h1>
+        <p>
+          這裡是個幫你整理 ETF 配息的小天地，也附上簡單的持股追蹤工具。資料僅供參考，不構成投資建議唷！
+        </p>
+        <p>
+          這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～
+        </p>
+      </div>
+      <GuideTab />
+      <FaqTab />
+      <DisclaimerTab />
+      <TermsOfServiceTab />
+      <PrivacyPolicyTab />
+    </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,6 @@ import { useState, useEffect, useMemo } from 'react';
 import InventoryTab from './InventoryTab';
 import UserDividendsTab from './UserDividendsTab';
 import AboutTab from './AboutTab';
-import DisclaimerTab from './DisclaimerTab';
-import PrivacyPolicyTab from './PrivacyPolicyTab';
-import TermsOfServiceTab from './TermsOfServiceTab';
-import GuideTab from './GuideTab';
-import FaqTab from './FaqTab';
 import ActionDropdown from './components/ActionDropdown';
 import DisplayDropdown from './components/DisplayDropdown';
 import DividendCalendar from './components/DividendCalendar';
@@ -498,50 +493,10 @@ function App() {
         </li>
         <li className="nav-item">
           <button
-            className={`nav-link${tab === 'guide' ? ' active' : ''}`}
-            onClick={() => setTab('guide')}
-          >
-            使用說明
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
-            className={`nav-link${tab === 'faq' ? ' active' : ''}`}
-            onClick={() => setTab('faq')}
-          >
-            常見問題
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
             className={`nav-link${tab === 'about' ? ' active' : ''}`}
             onClick={() => setTab('about')}
           >
             關於本站
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
-            className={`nav-link${tab === 'disclaimer' ? ' active' : ''}`}
-            onClick={() => setTab('disclaimer')}
-          >
-            免責聲明
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
-            className={`nav-link${tab === 'terms' ? ' active' : ''}`}
-            onClick={() => setTab('terms')}
-          >
-            服務條款
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
-            className={`nav-link${tab === 'privacy' ? ' active' : ''}`}
-            onClick={() => setTab('privacy')}
-          >
-            隱私權政策
           </button>
         </li>
       </ul>
@@ -677,18 +632,13 @@ function App() {
         </div>
       )}
       {tab === 'inventory' && <InventoryTab />}
-      {tab === 'mydividend' &&
+      {tab === 'mydividend' && (
         <UserDividendsTab
           allDividendData={data}
           selectedYear={selectedYear}
         />
-      }
-      {tab === 'guide' && <GuideTab />}
-      {tab === 'faq' && <FaqTab />}
+      )}
       {tab === 'about' && <AboutTab />}
-      {tab === 'disclaimer' && <DisclaimerTab />}
-      {tab === 'terms' && <TermsOfServiceTab />}
-      {tab === 'privacy' && <PrivacyPolicyTab />}
       <div className="contact-wrapper">
         <div className="contact-section">
           <h3>聯絡方式</h3>


### PR DESCRIPTION
## Summary
- Move usage guide, FAQ, disclaimer, terms of service, and privacy policy into the About page
- Simplify navigation to show About as the single info tab

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1799e3fc8329bb0b2ce5de993812