### PR TITLE
feat: add tabs to about page

### DIFF
--- a/src/AboutTab.jsx
+++ b/src/AboutTab.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import GuideTab from './GuideTab';
 import FaqTab from './FaqTab';
 import DisclaimerTab from './DisclaimerTab';
@@ -6,6 +6,8 @@ import TermsOfServiceTab from './TermsOfServiceTab';
 import PrivacyPolicyTab from './PrivacyPolicyTab';
 
 export default function AboutTab() {
+  const [innerTab, setInnerTab] = useState('guide');
+
   return (
     <>
       <div className="container" style={{ maxWidth: 800 }}>
@@ -16,12 +18,54 @@ export default function AboutTab() {
         <p>
           這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～
         </p>
+        <ul className="nav nav-tabs mt-4 mb-3">
+          <li className="nav-item">
+            <button
+              className={`nav-link${innerTab === 'guide' ? ' active' : ''}`}
+              onClick={() => setInnerTab('guide')}
+            >
+              使用說明
+            </button>
+          </li>
+          <li className="nav-item">
+            <button
+              className={`nav-link${innerTab === 'faq' ? ' active' : ''}`}
+              onClick={() => setInnerTab('faq')}
+            >
+              常見問題
+            </button>
+          </li>
+          <li className="nav-item">
+            <button
+              className={`nav-link${innerTab === 'disclaimer' ? ' active' : ''}`}
+              onClick={() => setInnerTab('disclaimer')}
+            >
+              免責聲明
+            </button>
+          </li>
+          <li className="nav-item">
+            <button
+              className={`nav-link${innerTab === 'tos' ? ' active' : ''}`}
+              onClick={() => setInnerTab('tos')}
+            >
+              服務條款
+            </button>
+          </li>
+          <li className="nav-item">
+            <button
+              className={`nav-link${innerTab === 'privacy' ? ' active' : ''}`}
+              onClick={() => setInnerTab('privacy')}
+            >
+              隱私權政策
+            </button>
+          </li>
+        </ul>
       </div>
-      <GuideTab />
-      <FaqTab />
-      <DisclaimerTab />
-      <TermsOfServiceTab />
-      <PrivacyPolicyTab />
+      {innerTab === 'guide' && <GuideTab />}
+      {innerTab === 'faq' && <FaqTab />}
+      {innerTab === 'disclaimer' && <DisclaimerTab />}
+      {innerTab === 'tos' && <TermsOfServiceTab />}
+      {innerTab === 'privacy' && <PrivacyPolicyTab />}
     </>
   );
 }

--- a/src/AboutTab.test.jsx
+++ b/src/AboutTab.test.jsx
@@ -1,10 +1,21 @@
 /* eslint-env jest */
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import AboutTab from './AboutTab';
 
-test('renders about heading', () => {
+test('renders about heading and default tab', () => {
   render(<AboutTab />);
   expect(
     screen.getByRole('heading', { name: /關於本站/ })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { name: /使用小幫手/ })
+  ).toBeInTheDocument();
+});
+
+test('switches to FAQ tab when clicked', () => {
+  render(<AboutTab />);
+  fireEvent.click(screen.getByRole('button', { name: '常見問題' }));
+  expect(
+    screen.getByRole('heading', { name: /常見問題/ })
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- organize Guide, FAQ, Disclaimer, Terms of Service, and Privacy Policy into tabs on the About page
- test tab navigation behavior

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc255a2b7883299031db66884a8e85