### PR TITLE
Clear dividend cache after server update

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import './App.css';
 import styles from './App.module.css';
 import NLHelper from './NLHelper';
 import { API_HOST } from './config';
-import { fetchWithCache } from './api';
+import { fetchWithCache, clearCache } from './api';
 import { getTomorrowDividendAlerts } from './dividendUtils';
 
 const DEFAULT_MONTHLY_GOAL = 10000;
@@ -105,6 +105,7 @@ function App() {
   useEffect(() => {
     const callUpdate = () => {
       fetch(`${API_HOST}/update_dividend`).finally(() => {
+        clearCache(`${API_HOST}/get_dividend`);
         window.location.reload();
       });
     };

--- a/src/api.js
+++ b/src/api.js
@@ -66,3 +66,12 @@ export async function fetchWithCache(url) {
 
   throw new Error(`HTTP error! status: ${response.status}`);
 }
+
+export function clearCache(url) {
+  try {
+    localStorage.removeItem(`cache:data:${url}`);
+    localStorage.removeItem(`cache:meta:${url}`);
+  } catch {
+    // ignore errors
+  }
+}


### PR DESCRIPTION
## Summary
- add clearCache utility to remove cached API responses
- clear dividend cache after update_dividend so new data loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc73cceed48329aff2ea7ea4f223e2