### PR TITLE
feat: add filter column and fix dropdown alignment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -185,7 +185,7 @@ td {
   position: absolute;
   z-index: 99;
   top: 36px;
-  right: 0;
+  left: 0;
   background: var(--color-card-bg);
   border: 1px solid var(--color-border);
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.1);
@@ -614,4 +614,11 @@ button:active {
 
 .more-group .more-item {
   position: relative;
+}
+
+@media (max-width: 576px) {
+  .more-group {
+    width: 100%;
+    justify-content: center;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,7 @@ function App() {
 
   // Multi-select filters
   const [selectedStockIds, setSelectedStockIds] = useState([]);
+  const [extraFilters, setExtraFilters] = useState([]);
 
   // Watch groups
   const [watchGroups, setWatchGroups] = useState([]);
@@ -101,6 +102,7 @@ function App() {
     setMonthHasValue(Array(12).fill(false));
     setShowDiamondOnly(false);
     setShowAllStocks(false);
+    setExtraFilters([]);
   };
 
   useEffect(() => {
@@ -336,6 +338,27 @@ function App() {
     for (let m = 0; m < 12; ++m) {
       if (monthHasValue[m]) {
         if (!dividendTable[stock.stock_id] || !dividendTable[stock.stock_id][m]) return false;
+      }
+    }
+    if (extraFilters.length) {
+      const freqFilters = extraFilters
+        .filter(f => f.startsWith('freq'))
+        .map(f => Number(f.slice(4)));
+      if (freqFilters.length && !freqFilters.includes(freqMap[stock.stock_id])) return false;
+      if (extraFilters.includes('yield10')) {
+        let total = 0;
+        let count = 0;
+        for (let i = 0; i < 12; i++) {
+          const cell = dividendTable[stock.stock_id]?.[i];
+          const y = parseFloat(cell?.dividend_yield) || 0;
+          if (y > 0) {
+            total += y;
+            count += 1;
+          }
+        }
+        const freq = [1, 2, 4, 6, 12].includes(freqMap[stock.stock_id]) ? freqMap[stock.stock_id] : count;
+        const avg = count > 0 ? total / count : 0;
+        if (avg * freq < 10) return false;
       }
     }
     return true;
@@ -629,6 +652,8 @@ function App() {
               showInfoAxis={showInfoAxis}
               getIncomeGoalInfo={getIncomeGoalInfo}
               freqMap={freqMap}
+              extraFilters={extraFilters}
+              setExtraFilters={setExtraFilters}
             />
           )}
         </div>

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { API_HOST } from './config';
 import './App.css';
+import Footer from './components/Footer';
 
 export default function StockDetail({ stockId }) {
   const { data: stockList = [], isLoading: stockLoading, dataUpdatedAt: stockUpdatedAt } = useQuery({
@@ -59,7 +60,8 @@ export default function StockDetail({ stockId }) {
   const startDate = stock.dividend_start_date || stock.first_dividend_date;
 
   return (
-    <div className="stock-detail">
+    <>
+      <div className="stock-detail">
       <h1>{stock.stock_id} {stock.stock_name}</h1>
       {stockUpdatedAt && (
         <div style={{ textAlign: 'right', fontSize: 12 }}>
@@ -112,6 +114,8 @@ export default function StockDetail({ stockId }) {
         </div>
       )}
     </div>
+    <Footer />
+    </>
   );
 }
 

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -17,6 +17,15 @@ const freqNameMap = {
   12: '月配'
 };
 
+const EXTRA_FILTER_OPTIONS = [
+  { value: 'yield10', label: '預估殖利率≥10%' },
+  { value: 'freq12', label: '月配' },
+  { value: 'freq6', label: '雙月配' },
+  { value: 'freq4', label: '季配' },
+  { value: 'freq2', label: '半年配' },
+  { value: 'freq1', label: '年配' }
+];
+
 export default function StockTable({
   stocks,
   dividendTable,
@@ -40,10 +49,13 @@ export default function StockTable({
   setShowAllStocks,
   showInfoAxis,
   getIncomeGoalInfo,
-  freqMap
+  freqMap,
+  extraFilters,
+  setExtraFilters
 }) {
   const [sortConfig, setSortConfig] = useState({ column: 'stock_id', direction: 'asc' });
   const [showIdDropdown, setShowIdDropdown] = useState(false);
+  const [showExtraDropdown, setShowExtraDropdown] = useState(false);
 
   const handleSort = (column) => {
     setSortConfig(prev => {
@@ -117,6 +129,7 @@ export default function StockTable({
           </a>
         </td>
         <td style={{ width: NUM_COL_WIDTH }}>{latestPrice[stock.stock_id]?.price ?? ''}</td>
+        <td style={{ width: NUM_COL_WIDTH }}></td>
         {MONTHS.map((m, idx) => {
           const cell = dividendTable[stock.stock_id] && dividendTable[stock.stock_id][idx];
           if (!cell) return <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}></td>;
@@ -201,7 +214,13 @@ export default function StockTable({
           </tbody>
         </table>
         {!showAllStocks && sortedStocks.length > 20 && (
-          <button className="more-btn" onClick={() => setShowAllStocks(true)} style={{ marginTop: 8 }}>更多+</button>
+          <button
+            className="more-btn"
+            onClick={() => setShowAllStocks(true)}
+            style={{ marginTop: 8, display: 'block', marginLeft: 'auto', marginRight: 'auto' }}
+          >
+            更多+
+          </button>
         )}
       </div>
     );
@@ -212,7 +231,7 @@ export default function StockTable({
       {showAllStocks && (
         <button onClick={() => setShowAllStocks(false)} style={{ marginBottom: 8 }}>預設</button>
       )}
-      <table className="table table-bordered table-striped" style={{ minWidth: 1300 }}>
+      <table className="table table-bordered table-striped" style={{ minWidth: 1380 }}>
         <thead>
           <tr>
             <th className="stock-col">
@@ -250,6 +269,24 @@ export default function StockTable({
                     : '↕'}
                 </span>
               </span>
+            </th>
+            <th style={{ width: NUM_COL_WIDTH }}>
+              <span
+                className="filter-btn"
+                tabIndex={0}
+                onClick={() => setShowExtraDropdown(true)}
+                title="額外篩選"
+              >
+                🔎
+              </span>
+              {showExtraDropdown && (
+                <FilterDropdown
+                  options={EXTRA_FILTER_OPTIONS}
+                  selected={extraFilters}
+                  setSelected={setExtraFilters}
+                  onClose={() => setShowExtraDropdown(false)}
+                />
+              )}
             </th>
             {MONTHS.map((m, idx) => (
               <th key={m} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}>
@@ -304,7 +341,13 @@ export default function StockTable({
         </tbody>
       </table>
       {!showAllStocks && sortedStocks.length > 20 && (
-        <button className="more-btn" onClick={() => setShowAllStocks(true)} style={{ marginTop: 8 }}>更多+</button>
+        <button
+          className="more-btn"
+          onClick={() => setShowAllStocks(true)}
+          style={{ marginTop: 8, display: 'block', marginLeft: 'auto', marginRight: 'auto' }}
+        >
+          更多+
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- align "more" dropdown to open within viewport and center on mobile
- add extra filter column with yield and frequency options

## Testing
- `pnpm test` *(fails: pnpm not found)*
- `pnpm lint` *(fails: pnpm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd308a5ac88329b497c514d2619697