### PR TITLE
feat: add advanced filter options

### DIFF
--- a/src/components/AdvancedFilterDropdown.jsx
+++ b/src/components/AdvancedFilterDropdown.jsx
@@ -1,0 +1,70 @@
+import { useState, useRef } from 'react';
+import useClickOutside from './useClickOutside';
+
+export default function AdvancedFilterDropdown({ filters, setFilters, onClose }) {
+  const ref = useRef();
+  useClickOutside(ref, onClose);
+
+  const [temp, setTemp] = useState(filters);
+
+  const toggleFreq = (val) => {
+    setTemp(t => ({
+      ...t,
+      freq: t.freq.includes(val) ? t.freq.filter(f => f !== val) : [...t.freq, val]
+    }));
+  };
+
+  const handleClear = () => {
+    setTemp({ minYield: '', freq: [], upcomingWithin: '' });
+  };
+
+  const handleApply = () => {
+    setFilters(temp);
+    onClose();
+  };
+
+  return (
+    <div className="dropdown" ref={ref} style={{ padding: 8 }}>
+      <div className="dropdown-section">
+        <label>
+          預估殖利率 ≥
+          <input
+            type="number"
+            value={temp.minYield}
+            onChange={e => setTemp({ ...temp, minYield: e.target.value })}
+            style={{ width: 60, marginLeft: 4 }}
+          />%
+        </label>
+      </div>
+      <hr />
+      <div className="dropdown-section" style={{ maxHeight: 100, overflowY: 'auto' }}>
+        {[{ v: 12, l: '月配' }, { v: 6, l: '雙月配' }, { v: 4, l: '季配' }, { v: 2, l: '半年配' }, { v: 1, l: '年配' }].map(opt => (
+          <label key={opt.v} className="dropdown-item">
+            <input
+              type="checkbox"
+              checked={temp.freq.includes(opt.v)}
+              onChange={() => toggleFreq(opt.v)}
+            /> {opt.l}
+          </label>
+        ))}
+      </div>
+      <hr />
+      <div className="dropdown-section">
+        <label>
+          即將除息/發息：未來
+          <input
+            type="number"
+            value={temp.upcomingWithin}
+            onChange={e => setTemp({ ...temp, upcomingWithin: e.target.value })}
+            style={{ width: 60, margin: '0 4px' }}
+          />天內
+        </label>
+      </div>
+      <div style={{ marginTop: 8, textAlign: 'right' }}>
+        <button className="dropdown-btn" onClick={handleClear}>清除</button>
+        <button className="dropdown-btn" style={{ marginLeft: 8 }} onClick={handleApply}>確定</button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 // Removed react-window virtualization to avoid invalid table markup
 import FilterDropdown from './FilterDropdown';
+import AdvancedFilterDropdown from './AdvancedFilterDropdown';
 
 const MONTHS = [
   '1月', '2月', '3月', '4月', '5月', '6月',
@@ -16,15 +17,6 @@ const freqNameMap = {
   6: '雙月配',
   12: '月配'
 };
-
-const EXTRA_FILTER_OPTIONS = [
-  { value: 'yield10', label: '預估殖利率≥10%' },
-  { value: 'freq12', label: '月配' },
-  { value: 'freq6', label: '雙月配' },
-  { value: 'freq4', label: '季配' },
-  { value: 'freq2', label: '半年配' },
-  { value: 'freq1', label: '年配' }
-];
 
 export default function StockTable({
   stocks,
@@ -270,24 +262,23 @@ export default function StockTable({
                 </span>
               </span>
             </th>
-            <th style={{ width: NUM_COL_WIDTH }}>
-              <span
-                className="filter-btn"
-                tabIndex={0}
-                onClick={() => setShowExtraDropdown(true)}
-                title="額外篩選"
-              >
-                🔎
-              </span>
-              {showExtraDropdown && (
-                <FilterDropdown
-                  options={EXTRA_FILTER_OPTIONS}
-                  selected={extraFilters}
-                  setSelected={setExtraFilters}
-                  onClose={() => setShowExtraDropdown(false)}
-                />
-              )}
-            </th>
+              <th style={{ width: NUM_COL_WIDTH }}>
+                <span
+                  className="filter-btn"
+                  tabIndex={0}
+                  onClick={() => setShowExtraDropdown(true)}
+                  title="進階篩選"
+                >
+                  🔎
+                </span>
+                {showExtraDropdown && (
+                  <AdvancedFilterDropdown
+                    filters={extraFilters}
+                    setFilters={setExtraFilters}
+                    onClose={() => setShowExtraDropdown(false)}
+                  />
+                )}
+              </th>
             {MONTHS.map((m, idx) => (
               <th key={m} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}>
                 <span className="sortable" onClick={() => handleSort(`month${idx}`)}>


### PR DESCRIPTION
## Summary
- add AdvancedFilterDropdown for yield, frequency, and date range filters
- integrate advanced filter column in stock table
- support filtering stocks by custom yield threshold, payout frequency, and upcoming dates

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7025b7dc83299fef3503d352e824