### PR TITLE
Ensure AdvancedFilterDropdown renders above other elements

### DIFF
--- a/src/components/AdvancedFilterDropdown.jsx
+++ b/src/components/AdvancedFilterDropdown.jsx
@@ -24,7 +24,7 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
   };
 
   return (
-    <div className="dropdown" ref={ref} style={{ padding: 8 }}>
+    <div className="dropdown" ref={ref} style={{ padding: 8, zIndex: 1000 }}>
       <div className="dropdown-section">
         <label>
           預估殖利率 ≥

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -262,7 +262,7 @@ export default function StockTable({
                 </span>
               </span>
             </th>
-              <th style={{ width: NUM_COL_WIDTH }}>
+              <th style={{ width: NUM_COL_WIDTH, zIndex: showExtraDropdown ? 1000 : undefined }}>
                 <span
                   className="filter-btn"
                   tabIndex={0}


### PR DESCRIPTION
## Summary
- Raise AdvancedFilterDropdown z-index so the dropdown stays above surrounding UI
- Elevate table header z-index when advanced filter is open so the menu isn't covered by table rows

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9b4b04048329a0e1a282b8713ba8