### PR TITLE
Ensure AdvancedFilterDropdown overlays contact section

### DIFF
--- a/src/components/AdvancedFilterDropdown.jsx
+++ b/src/components/AdvancedFilterDropdown.jsx
@@ -24,7 +24,7 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
   };
 
   return (
-    <div className="dropdown" ref={ref} style={{ padding: 8, zIndex: 1000 }}>
+    <div className="dropdown" ref={ref} style={{ padding: 8, zIndex: 9999 }}>
       <div className="dropdown-section">
         <label>
           預估殖利率 ≥

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -262,7 +262,7 @@ export default function StockTable({
                 </span>
               </span>
             </th>
-              <th style={{ width: NUM_COL_WIDTH, zIndex: showExtraDropdown ? 1000 : undefined }}>
+              <th style={{ width: NUM_COL_WIDTH, zIndex: showExtraDropdown ? 9999 : undefined }}>
                 篩選
                 <span
                   className="filter-btn"


### PR DESCRIPTION
## Summary
- elevate AdvancedFilterDropdown z-index so dropdown appears above contact section

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9f8437dc8329b3c8211561276477