### PR TITLE
Use SVG assets for site logo and title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/conceptB-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="canonical" href="https://etflife.org/" />
     <link

--- a/src/App.css
+++ b/src/App.css
@@ -29,8 +29,13 @@
 
 @media (prefers-reduced-motion: no-preference) {
   a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  animation: logo-spin infinite 20s linear;
   }
+}
+
+.site-logo {
+  height: 80px;
+  width: auto;
 }
 
 .card {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import Footer from './components/Footer';
 
 import './App.css';
 import styles from './App.module.css';
+import dividendLogoDark from './assets/conceptB-Dividend-Life-dark.svg';
+import dividendLogoLight from './assets/conceptB-Dividend-Life-light.svg';
 import NLHelper from './NLHelper';
 import { API_HOST } from './config';
 import { fetchWithCache, clearCache } from './api';
@@ -494,10 +496,13 @@ function App() {
 
   return (
     <div className="container">
-      <header className="mb-1 text-center">
-        <h1 className="site-title">股息人生</h1>
-        <h2 className="slogan">compound interest is the most powerful force in the universe</h2>
-      </header>
+    <header className="mb-1 text-center">
+      <img
+        src={theme === 'dark' ? dividendLogoDark : dividendLogoLight}
+        alt="股息人生"
+        className="site-logo"
+      />
+    </header>
       {upcomingAlerts.length > 0 && (
         <div className="dividend-alert">
           {upcomingAlerts.map(a => (


### PR DESCRIPTION
## Summary
- replace default favicon with `conceptB-icon.svg`
- display `Dividend Life` SVG logo that swaps for dark/light themes
- style logo sizing

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdadb8e7e48329ac34d2dcefb54e03