### PR TITLE
refactor: use link style for theme toggle and donation

### DIFF
--- a/src/Footer.test.jsx
+++ b/src/Footer.test.jsx
@@ -4,7 +4,7 @@ import Footer from './components/Footer.jsx';
 test('renders contact info and dynamic copyright', () => {
   const year = new Date().getFullYear();
   render(<Footer theme="dark" toggleTheme={() => {}} />);
-  expect(screen.getByRole('button', { name: '亮色主題' })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: '亮色主題' })).toBeInTheDocument();
   expect(screen.getByText('聯絡方式')).toBeInTheDocument();
   expect(screen.getByRole('link', { name: '贊助' })).toBeInTheDocument();
   expect(

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -16,35 +16,17 @@
   margin-bottom: 1rem;
 }
 
+.theme-toggle-link {
+  cursor: pointer;
+}
+
 .donation-section {
   margin-top: 0.5rem;
 }
 
-.donate-button {
+.donate-link {
   display: inline-block;
   margin-top: 0.5rem;
-  background: var(--accent-gold);
-  color: var(--color-text);
-  border: none;
-  border-radius: 6px;
-  font-weight: 500;
-  padding: 6px 14px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
-}
-
-.donate-button:hover,
-.donate-button:focus {
-  background: var(--accent-gold-hover);
-  color: var(--color-text);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(255, 215, 0, 0.3);
-}
-
-.donate-button:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgba(255, 215, 0, 0.2);
 }
 
 .copyright {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,9 +6,16 @@ export default function Footer({ theme, toggleTheme }) {
     <footer className="footer">
       <div className="footer-content">
         <div className="theme-toggle">
-          <button onClick={toggleTheme}>
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              toggleTheme();
+            }}
+            className="theme-toggle-link"
+          >
             {theme === 'dark' ? '亮色主題' : '暗色主題'}
-          </button>
+          </a>
         </div>
         <div className="contact-section">
           <h3>聯絡方式</h3>
@@ -23,7 +30,7 @@ export default function Footer({ theme, toggleTheme }) {
             href="https://www.buymeacoffee.com/ginatbean"
             target="_blank"
             rel="noreferrer"
-            className="donate-button"
+            className="donate-link"
           >
             贊助
           </a>


### PR DESCRIPTION
## Summary
- convert theme toggle to link element
- simplify donation to plain hyperlink
- adjust footer tests for link-based controls

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdbd86aacc832988a712b4ee66e31b