### PR TITLE
Fix logo overflowing on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,8 +34,9 @@
 }
 
 .site-logo {
-  height: 180px;
-  width: auto;
+  width: 100%;
+  height: auto;
+  max-height: 180px;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- Prevent header logo from exceeding its container on small screens by making it responsive.

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68be43d444e08329a0b61e3b8aaf8bfd