### PR TITLE
Fix missing ETF options when adding transactions

### DIFF
--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -14,10 +14,13 @@ describe('InventoryTab interactions', () => {
     localStorage.clear();
     Cookies.remove('my_transaction_history');
     fetchWithCache.mockImplementation((url) => {
-      if (url.endsWith('/get_stock_list')) {
-        return Promise.resolve({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
+      if (url.includes('/get_stock_list')) {
+        if (url.includes('page=1')) {
+          return Promise.resolve({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
+        }
+        return Promise.resolve({ data: [] });
       }
-      if (url.endsWith('/get_dividend')) {
+      if (url.includes('/get_dividend')) {
         return Promise.resolve({ data: [{ stock_id: '0050', dividend_date: '2024-01-02', last_close_price: 20 }] });
       }
       return Promise.resolve({ data: [] });


### PR DESCRIPTION
## Summary
- fetch all pages of stock list so every ETF appears in add transaction modal
- update tests to support paginated stock list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be4bce2c9883299e162686b42db503