### PR TITLE
Highlight current month in dividend overview

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,7 +98,8 @@ function App() {
   // Month value existence filters
   const [monthHasValue, setMonthHasValue] = useState(Array(12).fill(false));
   const [freqMap, setFreqMap] = useState({});
-  const currentMonth = new Date().getMonth();
+  const timeZone = 'Asia/Taipei';
+  const currentMonth = Number(new Date().toLocaleString('en-US', { timeZone, month: 'numeric' })) - 1;
   const handleResetFilters = (keepIds = false) => {
       if (!keepIds) setSelectedStockIds([]);
       setMonthHasValue(Array(12).fill(false));

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -19,7 +19,8 @@ function getTransactionHistory() {
 export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const [history, setHistory] = useState([]);
     const [showCalendar, setShowCalendar] = useState(false);
-    const currentMonth = new Date().getMonth();
+    const timeZone = 'Asia/Taipei';
+    const currentMonth = Number(new Date().toLocaleString('en-US', { timeZone, month: 'numeric' })) - 1;
     const [sortConfig, setSortConfig] = useState({ column: 'stock_id', direction: 'asc' });
     useEffect(() => {
         setHistory(getTransactionHistory());


### PR DESCRIPTION
## Summary
- Derive current month using Asia/Taipei timezone for correct column highlighting.
- Use timezone-based month calculation in user dividend summary table.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be508f750483299406943fd83cdb9d