### PR TITLE
Highlight current month in dividend tables

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -99,7 +99,8 @@ td {
 }
 
 .current-month {
-  background: var(--color-hover);
+  background: rgba(255, 224, 102, 0.4);
+  font-weight: bold;
 }
 
 .crown-icon {


### PR DESCRIPTION
## Summary
- Emphasize current month columns in dividend overview and monthly summary tables with a bold, yellow-tinted background.

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68be93e974048329a32661e3b4d85ee2