### PR TITLE
feat: highlight current month in dividend tables

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -101,6 +101,7 @@ td {
 .current-month {
   background: rgba(255, 224, 102, 0.4);
   font-weight: bold;
+  color: #d62828;
 }
 
 .crown-icon {


### PR DESCRIPTION
## Summary
- highlight current month in tables by adding red text color

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb0dcdfd483299ed78bb942d1c9dc