### PR TITLE
Restore hide toggle in monthly dividend table

### DIFF
--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -157,9 +157,6 @@ export default function StockTable({
   if (showInfoAxis) {
     return (
       <div className="table-responsive">
-        {showAllStocks && (
-          <button onClick={() => setShowAllStocks(false)} style={{ marginBottom: 8 }}>預設</button>
-        )}
         <table className="table table-bordered table-striped">
           <thead>
             <tr>
@@ -205,13 +202,13 @@ export default function StockTable({
             })}
           </tbody>
         </table>
-        {!showAllStocks && sortedStocks.length > 20 && (
+        {sortedStocks.length > 20 && (
           <button
             className="more-btn"
-            onClick={() => setShowAllStocks(true)}
+            onClick={() => setShowAllStocks(v => !v)}
             style={{ marginTop: 8, display: 'block', marginLeft: 'auto', marginRight: 'auto' }}
           >
-            更多+
+            {showAllStocks ? '隱藏-' : '更多+'}
           </button>
         )}
       </div>
@@ -220,9 +217,6 @@ export default function StockTable({
 
   return (
     <div className="table-responsive">
-      {showAllStocks && (
-        <button onClick={() => setShowAllStocks(false)} style={{ marginBottom: 8 }}>預設</button>
-      )}
       <table className="table table-bordered table-striped" style={{ minWidth: 1380 }}>
         <thead>
           <tr>
@@ -332,13 +326,13 @@ export default function StockTable({
           ))}
         </tbody>
       </table>
-      {!showAllStocks && sortedStocks.length > 20 && (
+      {sortedStocks.length > 20 && (
         <button
           className="more-btn"
-          onClick={() => setShowAllStocks(true)}
+          onClick={() => setShowAllStocks(v => !v)}
           style={{ marginTop: 8, display: 'block', marginLeft: 'auto', marginRight: 'auto' }}
         >
-          更多+
+          {showAllStocks ? '隱藏-' : '更多+'}
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Restore missing `隱藏-` toggle for ETF monthly dividend table
- Toggle now switches between showing full list and default in both table modes

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68beb564b0b883299e2db3e73dd58dbf