### PR TITLE
Add home tab with site overview

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import InventoryTab from './InventoryTab';
 import UserDividendsTab from './UserDividendsTab';
 import AboutTab from './AboutTab';
+import HomeTab from './HomeTab';
 import ActionDropdown from './components/ActionDropdown';
 import DisplayDropdown from './components/DisplayDropdown';
 import DividendCalendar from './components/DividendCalendar';
@@ -44,7 +45,7 @@ function getIncomeGoalInfo(dividend, price, goal, freq = 12) {
 
 function App() {
   // Tab state
-  const [tab, setTab] = useState('mydividend');
+  const [tab, setTab] = useState('home');
 
   // All your existing states for dividend page...
   const [data, setData] = useState([]);
@@ -516,6 +517,14 @@ function App() {
       <ul className="nav nav-tabs mb-1 justify-content-center">
         <li className="nav-item">
           <button
+            className={`nav-link${tab === 'home' ? ' active' : ''}`}
+            onClick={() => setTab('home')}
+          >
+            首頁
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
             className={`nav-link${tab === 'mydividend' ? ' active' : ''}`}
             onClick={() => setTab('mydividend')}
           >
@@ -547,6 +556,7 @@ function App() {
           </button>
         </li>
       </ul>
+      {tab === 'home' && <HomeTab />}
       {tab === 'dividend' && (
         <div className="App">
           <h3>ETF 每月配息總表</h3>

--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react';
+
+const milestones = [
+  { value: '80+', label: '已收錄台灣 ETF' },
+  { value: '20,000+', label: '累積配息紀錄' },
+  { value: '10+ 年', label: '歷史資料涵蓋' }
+];
+
+const latest = [
+  '✅ 已更新 2025 年 9 月最新配息數據',
+  '📊 新增 ETF：00943 台新永續高息'
+];
+
+const tips = [
+  '你知道嗎？ETF 的配息頻率通常有「月配、季配、半年配、年配」四種。',
+  '高股息 ETF 不代表報酬率高，還需要考慮殖利率與價格變化。'
+];
+
+export default function HomeTab() {
+  const tip = useMemo(() => tips[Math.floor(Math.random() * tips.length)], []);
+  return (
+    <div className="container" style={{ maxWidth: 800 }}>
+      <section className="mt-4">
+        <h2>本站數據概況</h2>
+        <div style={{ display: 'flex', justifyContent: 'space-between', textAlign: 'center', marginTop: 16 }}>
+          {milestones.map((m, idx) => (
+            <div key={idx} style={{ flex: 1 }}>
+              <div style={{ fontSize: 32, fontWeight: 'bold' }}>{m.value}</div>
+              <div>{m.label}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="mt-4">
+        <h2>最新收錄</h2>
+        <ul>
+          {latest.map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>
+      </section>
+      <section className="mt-4" style={{ background: '#f5f5f5', padding: 16, borderRadius: 4 }}>
+        <h2>ETF 小知識</h2>
+        <p style={{ margin: 0 }}>{tip}</p>
+      </section>
+    </div>
+  );
+}

--- a/src/HomeTab.test.jsx
+++ b/src/HomeTab.test.jsx
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import HomeTab from './HomeTab';
+
+test('renders data milestones section', () => {
+  render(<HomeTab />);
+  expect(screen.getByText('本站數據概況')).toBeInTheDocument();
+  expect(screen.getByText('80+')).toBeInTheDocument();
+});
+
+test('renders latest updates section', () => {
+  render(<HomeTab />);
+  expect(screen.getByText('最新收錄')).toBeInTheDocument();
+});
+
+test('renders knowledge section', () => {
+  render(<HomeTab />);
+  expect(screen.getByText('ETF 小知識')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- introduce HomeTab showing site data milestones, latest updates, and ETF tips
- link new Home tab in navigation and set as default landing page
- add tests for HomeTab component

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bed4bf86248329a744f1a5b1bbb40b