### PR TITLE
feat: load site stats on home tab

### DIFF
--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -1,29 +1,33 @@
-import React, { useMemo } from 'react';
-
-const milestones = [
-  { value: '80+', label: '已收錄台灣 ETF' },
-  { value: '20,000+', label: '累積配息紀錄' },
-  { value: '10+ 年', label: '歷史資料涵蓋' }
-];
-
-const latest = [
-  '✅ 已更新 2025 年 9 月最新配息數據',
-  '📊 新增 ETF：00943 台新永續高息'
-];
-
-const tips = [
-  '你知道嗎？ETF 的配息頻率通常有「月配、季配、半年配、年配」四種。',
-  '高股息 ETF 不代表報酬率高，還需要考慮殖利率與價格變化。'
-];
+import React, { useEffect, useState } from 'react';
 
 export default function HomeTab() {
-  const tip = useMemo(() => tips[Math.floor(Math.random() * tips.length)], []);
+  const [stats, setStats] = useState({ milestones: [], latest: [], tip: '' });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('http://127.0.0.1:8001/site_stats')
+      .then(res => res.json())
+      .then(data => {
+        if (!cancelled) {
+          setStats({
+            milestones: Array.isArray(data?.milestones) ? data.milestones : [],
+            latest: Array.isArray(data?.latest) ? data.latest : [],
+            tip: data?.tip || '',
+          });
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <div className="container" style={{ maxWidth: 800 }}>
       <section className="mt-4">
         <h2>本站數據概況</h2>
         <div style={{ display: 'flex', justifyContent: 'space-between', textAlign: 'center', marginTop: 16 }}>
-          {milestones.map((m, idx) => (
+          {stats.milestones.map((m, idx) => (
             <div key={idx} style={{ flex: 1 }}>
               <div style={{ fontSize: 32, fontWeight: 'bold' }}>{m.value}</div>
               <div>{m.label}</div>
@@ -34,15 +38,16 @@ export default function HomeTab() {
       <section className="mt-4">
         <h2>最新收錄</h2>
         <ul>
-          {latest.map((item, idx) => (
+          {stats.latest.map((item, idx) => (
             <li key={idx}>{item}</li>
           ))}
         </ul>
       </section>
       <section className="mt-4" style={{ background: '#f5f5f5', padding: 16, borderRadius: 4 }}>
         <h2>ETF 小知識</h2>
-        <p style={{ margin: 0 }}>{tip}</p>
+        <p style={{ margin: 0 }}>{stats.tip}</p>
       </section>
     </div>
   );
 }
+

--- a/src/HomeTab.test.jsx
+++ b/src/HomeTab.test.jsx
@@ -2,18 +2,49 @@
 import { render, screen } from '@testing-library/react';
 import HomeTab from './HomeTab';
 
-test('renders data milestones section', () => {
-  render(<HomeTab />);
-  expect(screen.getByText('本站數據概況')).toBeInTheDocument();
-  expect(screen.getByText('80+')).toBeInTheDocument();
+const mockData = {
+  milestones: [
+    { label: '已收錄台灣 ETF', value: 301 },
+    { label: '累積配息紀錄', value: 1432 },
+    { label: '歷史資料涵蓋', value: 21 }
+  ],
+  latest: [
+    '✅ 已更新 2025 年 9 月最新配息數據',
+    '📊 新增 ETF：009805 新光美國電力基建'
+  ],
+  tip: '高股息 ETF 不代表報酬率高，還需要考慮殖利率與價格變化。'
+};
+
+beforeEach(() => {
+  globalThis.fetch = jest.fn().mockResolvedValue({
+    json: jest.fn().mockResolvedValue(mockData)
+  });
 });
 
-test('renders latest updates section', () => {
-  render(<HomeTab />);
-  expect(screen.getByText('最新收錄')).toBeInTheDocument();
+afterEach(() => {
+  jest.resetAllMocks();
 });
 
-test('renders knowledge section', () => {
+test('renders data milestones section', async () => {
   render(<HomeTab />);
-  expect(screen.getByText('ETF 小知識')).toBeInTheDocument();
+  await screen.findByText('本站數據概況');
+  expect(await screen.findByText('301')).toBeInTheDocument();
+});
+
+test('renders latest updates section', async () => {
+  render(<HomeTab />);
+  await screen.findByText('最新收錄');
+  expect(
+    await screen.findByText('✅ 已更新 2025 年 9 月最新配息數據')
+  ).toBeInTheDocument();
+});
+
+test('renders knowledge section', async () => {
+  render(<HomeTab />);
+  await screen.findByText('ETF 小知識');
+  expect(
+    await screen.findByText(
+      '高股息 ETF 不代表報酬率高，還需要考慮殖利率與價格變化。'
+    )
+  ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fetch site statistics from local API endpoint in HomeTab
- display milestones, latest updates, and tip from API response
- add tests mocking the API call

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68beefb412c88329b5529baf10751ad5