### PR TITLE
Ensure current month column highlight overrides table styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -99,9 +99,9 @@ td {
 }
 
 .current-month {
-  background: rgba(255, 224, 102, 0.4);
+  background-color: rgba(255, 224, 102, 0.4) !important;
   font-weight: bold;
-  color: #d62828;
+  color: #d62828 !important;
 }
 
 .crown-icon {


### PR DESCRIPTION
## Summary
- force current-month table cells to use custom background and text colors

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf0e9f5c108329b113ea38110bb976