### PR TITLE
feat: add Google Drive sync

### DIFF
--- a/src/googleDrive.js
+++ b/src/googleDrive.js
@@ -1,0 +1,72 @@
+const CLIENT_ID = typeof window !== 'undefined' && window.GOOGLE_CLIENT_ID ? window.GOOGLE_CLIENT_ID : '';
+const API_KEY = typeof window !== 'undefined' && window.GOOGLE_API_KEY ? window.GOOGLE_API_KEY : '';
+const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
+let initialized = false;
+
+async function loadScript() {
+  if (document.getElementById('gapi')) return;
+  await new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = 'gapi';
+    script.src = 'https://apis.google.com/js/api.js';
+    script.onload = resolve;
+    script.onerror = reject;
+    document.body.appendChild(script);
+  });
+}
+
+export async function initDrive() {
+  if (initialized) return;
+  await loadScript();
+  await new Promise((resolve) => {
+    window.gapi.load('client:auth2', resolve);
+  });
+  await window.gapi.client.init({
+    apiKey: API_KEY,
+    clientId: CLIENT_ID,
+    discoveryDocs: DISCOVERY_DOCS,
+    scope: SCOPES
+  });
+  initialized = true;
+}
+
+function toCsv(list) {
+  const header = ['stock_id', 'date', 'quantity', 'type', 'price'];
+  const rows = list.map(item => [
+    item.stock_id,
+    item.date,
+    item.quantity,
+    item.type,
+    item.price ?? ''
+  ]);
+  return [header, ...rows].map(r => r.join(',')).join('\n');
+}
+
+export async function exportTransactionsToDrive(list) {
+  await initDrive();
+  const csv = toCsv(list);
+  const file = new Blob([csv], { type: 'text/csv' });
+  const metadata = { name: 'inventory_backup.csv', mimeType: 'text/csv' };
+  const accessToken = window.gapi.auth.getToken().access_token;
+  const form = new FormData();
+  form.append('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
+  form.append('file', file);
+  await fetch('https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id', {
+    method: 'POST',
+    headers: new Headers({ 'Authorization': 'Bearer ' + accessToken }),
+    body: form
+  });
+}
+
+export async function importTransactionsFromDrive() {
+  await initDrive();
+  const list = await window.gapi.client.drive.files.list({
+    q: "name='inventory_backup.csv' and trashed=false",
+    fields: 'files(id)'
+  });
+  if (!list.result.files || list.result.files.length === 0) return null;
+  const fileId = list.result.files[0].id;
+  const file = await window.gapi.client.drive.files.get({ fileId, alt: 'media' });
+  return file.body;
+}


### PR DESCRIPTION
## Summary
- add Google Drive helper for uploading and downloading transaction backups
- wire InventoryTab to export/import via Google Drive
- auto-export transaction history to Google Drive whenever it changes
- auto-import transaction history from Google Drive when local data differs and remove manual Drive buttons

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf6f0204e48329b81b66c2a0475f2e