### PR TITLE
Remove nested tabs on about page

### DIFF
--- a/src/AboutTab.jsx
+++ b/src/AboutTab.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import GuideTab from './GuideTab';
 import FaqTab from './FaqTab';
 import DisclaimerTab from './DisclaimerTab';
@@ -6,8 +6,6 @@ import TermsOfServiceTab from './TermsOfServiceTab';
 import PrivacyPolicyTab from './PrivacyPolicyTab';
 
 export default function AboutTab() {
-  const [innerTab, setInnerTab] = useState('guide');
-
   return (
     <>
       <div className="container" style={{ maxWidth: 800 }}>
@@ -18,54 +16,12 @@ export default function AboutTab() {
         <p>
           這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～
         </p>
-        <ul className="nav nav-tabs mt-4 mb-3">
-          <li className="nav-item">
-            <button
-              className={`nav-link${innerTab === 'guide' ? ' active' : ''}`}
-              onClick={() => setInnerTab('guide')}
-            >
-              使用說明
-            </button>
-          </li>
-          <li className="nav-item">
-            <button
-              className={`nav-link${innerTab === 'faq' ? ' active' : ''}`}
-              onClick={() => setInnerTab('faq')}
-            >
-              常見問題
-            </button>
-          </li>
-          <li className="nav-item">
-            <button
-              className={`nav-link${innerTab === 'disclaimer' ? ' active' : ''}`}
-              onClick={() => setInnerTab('disclaimer')}
-            >
-              免責聲明
-            </button>
-          </li>
-          <li className="nav-item">
-            <button
-              className={`nav-link${innerTab === 'tos' ? ' active' : ''}`}
-              onClick={() => setInnerTab('tos')}
-            >
-              服務條款
-            </button>
-          </li>
-          <li className="nav-item">
-            <button
-              className={`nav-link${innerTab === 'privacy' ? ' active' : ''}`}
-              onClick={() => setInnerTab('privacy')}
-            >
-              隱私權政策
-            </button>
-          </li>
-        </ul>
       </div>
-      {innerTab === 'guide' && <GuideTab />}
-      {innerTab === 'faq' && <FaqTab />}
-      {innerTab === 'disclaimer' && <DisclaimerTab />}
-      {innerTab === 'tos' && <TermsOfServiceTab />}
-      {innerTab === 'privacy' && <PrivacyPolicyTab />}
+      <GuideTab />
+      <FaqTab />
+      <DisclaimerTab />
+      <TermsOfServiceTab />
+      <PrivacyPolicyTab />
     </>
   );
 }

--- a/src/AboutTab.test.jsx
+++ b/src/AboutTab.test.jsx
@@ -1,8 +1,8 @@
 /* eslint-env jest */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import AboutTab from './AboutTab';
 
-test('renders about heading and default tab', () => {
+test('renders about heading and all sections', () => {
   render(<AboutTab />);
   expect(
     screen.getByRole('heading', { name: /關於本站/ })
@@ -10,12 +10,16 @@ test('renders about heading and default tab', () => {
   expect(
     screen.getByRole('heading', { name: /使用小幫手/ })
   ).toBeInTheDocument();
-});
-
-test('switches to FAQ tab when clicked', () => {
-  render(<AboutTab />);
-  fireEvent.click(screen.getByRole('button', { name: '常見問題' }));
   expect(
     screen.getByRole('heading', { name: /常見問題/ })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { name: /免責聲明/ })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { name: /服務條款/ })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { name: /隱私權政策/ })
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- simplify About page by displaying guide, FAQ, disclaimer, terms of service, and privacy policy sequentially
- update About tab tests for new layout

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 'process' is not defined in InventoryTab.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7cd02ba083298a0604fe39086216