### PR TITLE
feat: show my dividend calendar and table

### DIFF
--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -18,7 +18,7 @@ function getTransactionHistory() {
 
 export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const [history, setHistory] = useState([]);
-    const [showCalendar, setShowCalendar] = useState(false);
+    const [showTable, setShowTable] = useState(true);
     const timeZone = 'Asia/Taipei';
     const currentMonth = Number(new Date().toLocaleString('en-US', { timeZone, month: 'numeric' })) - 1;
     const [sortConfig, setSortConfig] = useState({ column: 'stock_id', direction: 'asc' });
@@ -190,14 +190,16 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
         <div className="App" style={{ margin: '0 auto' }}>
             <div style={{ display: "flex", alignItems: "center", margin: "10px 0 0 0", gap: "8px"}}>
                 <h3>{selectedYear} 配息總覽</h3>
-                <button onClick={() => setShowCalendar(v => !v)}>
-                    {showCalendar ? '顯示表格' : '顯示月曆'}
+            </div>
+            <div style={{ margin: '10px 0' }}>
+                <button onClick={() => setShowTable(v => !v)}>
+                    {showTable ? '隱藏表格' : '顯示表格'}
                 </button>
             </div>
 
-            {showCalendar ? (
-                <DividendCalendar year={selectedYear} events={calendarEvents} />
-            ) : (
+            <DividendCalendar year={selectedYear} events={calendarEvents} />
+
+            {showTable && (
             <div className="table-responsive">
             <table className="table table-bordered table-striped">
                 <thead>
@@ -293,7 +295,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
             </table>
             </div>
             )}
-            {!showCalendar && (
+            {showTable && (
                 <p style={{ fontSize: 12, marginTop: 8, color: '#666' }}>
                     提示：滑鼠移到數字可看持股、每股配息及日期、價格與殖利率細節。
                 </p>


### PR DESCRIPTION
## Summary
- show calendar and table simultaneously in dividend overview
- add button to hide or display dividend table

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb251ba6483298095e96124b92302