### PR TITLE
feat: improve dividend layout and logo

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,8 +41,8 @@
 
 @media (max-width: 576px) {
   .site-logo {
-    width: calc(100% + 4rem);
-    margin: 0 -2rem;
+    width: 100%;
+    margin: 0 auto;
   }
 }
 
@@ -610,7 +610,7 @@ button:active {
   gap: 8px;
 }
 
-.more-group .more-item {
+.more-item {
   position: relative;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,8 +55,8 @@ function App() {
   const [error, setError] = useState(null);
   const [upcomingAlerts, setUpcomingAlerts] = useState([]);
 
-  // Toggle table/calendar view
-  const [showCalendar, setShowCalendar] = useState(false);
+  // Toggle calendar visibility
+  const [showCalendar, setShowCalendar] = useState(true);
 
   // Filter which event types to show on calendar
   const [calendarFilter, setCalendarFilter] = useState('ex');
@@ -583,25 +583,58 @@ function App() {
             </div>
             <div className="more-group">
               <div className="more-item">
-                {!showCalendar &&
-                  <button onClick={() => setShowActions(v => !v)}>更多功能</button>
-                }
+                <button onClick={() => setShowActions(v => !v)}>更多功能</button>
                 {showActions && (
                   <ActionDropdown
                     openGroupModal={() => setShowGroupModal(true)}
                     monthlyIncomeGoal={monthlyIncomeGoal}
                     setMonthlyIncomeGoal={val => setMonthlyIncomeGoal(val)}
-                    showCalendar={showCalendar}
                     onClose={() => setShowActions(false)}
                   />
                 )}
               </div>
-              <div className="more-item">
+            </div>
+          </div>
+          <button onClick={() => setShowCalendar(v => !v)} style={{ marginTop: 10 }}>
+            {showCalendar ? '隱藏月曆' : '顯示月曆'}
+          </button>
+
+          {loading ? (
+            <p>Loading...</p>
+          ) : error ? (
+            <p>Error: {error.message}</p>
+          ) : (
+            <>
+              {showCalendar && (
+                <>
+                  <div style={{ margin: '10px 0' }}>
+                    <button
+                      onClick={() => setCalendarFilter('ex')}
+                      style={{ fontWeight: calendarFilter === 'ex' ? 'bold' : 'normal' }}
+                    >
+                      除息日
+                    </button>
+                    <button
+                      onClick={() => setCalendarFilter('pay')}
+                      style={{ fontWeight: calendarFilter === 'pay' ? 'bold' : 'normal', marginLeft: 6 }}
+                    >
+                      發放日
+                    </button>
+                    <button
+                      onClick={() => setCalendarFilter('both')}
+                      style={{ fontWeight: calendarFilter === 'both' ? 'bold' : 'normal', marginLeft: 6 }}
+                    >
+                      除息/發放日
+                    </button>
+                  </div>
+                  <DividendCalendar year={selectedYear} events={filteredCalendarEvents} />
+                </>
+              )}
+
+              <div className="more-item" style={{ marginTop: 10 }}>
                 <button onClick={() => setShowDisplays(v => !v)}>更多顯示</button>
                 {showDisplays && (
                   <DisplayDropdown
-                    toggleCalendar={() => setShowCalendar(v => !v)}
-                    showCalendar={showCalendar}
                     toggleDiamond={() => setShowDiamondOnly(v => !v)}
                     showDiamondOnly={showDiamondOnly}
                     toggleDividendYield={() => setShowDividendYield(v => !v)}
@@ -612,79 +645,47 @@ function App() {
                   />
                 )}
               </div>
-            </div>
-          </div>
-          <div className={styles.tableHeader}>
-            {!showCalendar && (
-              <>
+
+              <div className={styles.tableHeader}>
                 <button onClick={handleResetFilters} style={{ marginRight: 10 }}>重置所有篩選</button>
                 <span>提示：點下篩選鈕開啟篩選視窗。</span>
-              </>
-            )}
-          </div>
-          {dividendCacheInfo && (
-            <div className={styles.cacheInfo}>
-              快取: {dividendCacheInfo.cacheStatus}
-              {dividendCacheInfo.timestamp ? ` (${new Date(dividendCacheInfo.timestamp).toLocaleString()})` : ''}
-            </div>
-          )}
-
-          {loading ? (
-            <p>Loading...</p>
-          ) : error ? (
-            <p>Error: {error.message}</p>
-          ) : showCalendar ? (
-            <>
-              <div style={{ marginBottom: 5 }}>
-                <button
-                  onClick={() => setCalendarFilter('ex')}
-                  style={{ fontWeight: calendarFilter === 'ex' ? 'bold' : 'normal' }}
-                >
-                  除息日
-                </button>
-                <button
-                  onClick={() => setCalendarFilter('pay')}
-                  style={{ fontWeight: calendarFilter === 'pay' ? 'bold' : 'normal', marginLeft: 6 }}
-                >
-                  發放日
-                </button>
-                <button
-                  onClick={() => setCalendarFilter('both')}
-                  style={{ fontWeight: calendarFilter === 'both' ? 'bold' : 'normal', marginLeft: 6 }}
-                >
-                  除息/發放日
-                </button>
               </div>
-              <DividendCalendar year={selectedYear} events={filteredCalendarEvents} />
+
+              {dividendCacheInfo && (
+                <div className={styles.cacheInfo}>
+                  快取: {dividendCacheInfo.cacheStatus}
+                  {dividendCacheInfo.timestamp ? ` (${new Date(dividendCacheInfo.timestamp).toLocaleString()})` : ''}
+                </div>
+              )}
+
+              <StockTable
+                stocks={displayStocks}
+                dividendTable={dividendTable}
+                totalPerStock={totalPerStock}
+                yieldSum={yieldSum}
+                yieldCount={yieldCount}
+                latestPrice={latestPrice}
+                latestYield={latestYield}
+                estAnnualYield={estAnnualYield}
+                maxAnnualYield={maxAnnualYield}
+                maxYieldPerMonth={maxYieldPerMonth}
+                stockOptions={stockOptions}
+                selectedStockIds={selectedStockIds}
+                setSelectedStockIds={setSelectedStockIds}
+                monthHasValue={monthHasValue}
+                setMonthHasValue={setMonthHasValue}
+                showDividendYield={showDividendYield}
+                currentMonth={currentMonth}
+                monthlyIncomeGoal={monthlyIncomeGoal}
+                showAllStocks={showAllStocks}
+                setShowAllStocks={setShowAllStocks}
+                showInfoAxis={showInfoAxis}
+                getIncomeGoalInfo={getIncomeGoalInfo}
+                freqMap={freqMap}
+                extraFilters={extraFilters}
+                setExtraFilters={setExtraFilters}
+              />
             </>
-          ) : (
-            <StockTable
-              stocks={displayStocks}
-              dividendTable={dividendTable}
-              totalPerStock={totalPerStock}
-              yieldSum={yieldSum}
-              yieldCount={yieldCount}
-              latestPrice={latestPrice}
-              latestYield={latestYield}
-              estAnnualYield={estAnnualYield}
-              maxAnnualYield={maxAnnualYield}
-              maxYieldPerMonth={maxYieldPerMonth}
-              stockOptions={stockOptions}
-              selectedStockIds={selectedStockIds}
-              setSelectedStockIds={setSelectedStockIds}
-              monthHasValue={monthHasValue}
-              setMonthHasValue={setMonthHasValue}
-              showDividendYield={showDividendYield}
-              currentMonth={currentMonth}
-              monthlyIncomeGoal={monthlyIncomeGoal}
-              showAllStocks={showAllStocks}
-              setShowAllStocks={setShowAllStocks}
-              showInfoAxis={showInfoAxis}
-              getIncomeGoalInfo={getIncomeGoalInfo}
-              freqMap={freqMap}
-              extraFilters={extraFilters}
-              setExtraFilters={setExtraFilters}
-            />
           )}
         </div>
       )}

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -1,3 +1,4 @@
+/* global process */
 import { useState, useEffect, useRef, useCallback } from 'react';
 import Cookies from 'js-cookie';
 import { API_HOST } from './config';

--- a/src/components/ActionDropdown.jsx
+++ b/src/components/ActionDropdown.jsx
@@ -5,7 +5,6 @@ export default function ActionDropdown({
   openGroupModal,
   monthlyIncomeGoal,
   setMonthlyIncomeGoal,
-  showCalendar,
   onClose
 }) {
   const ref = useRef();
@@ -18,22 +17,18 @@ export default function ActionDropdown({
 
   return (
     <div className="action-dropdown" ref={ref}>
-      {!showCalendar && (
-        <>
-          <button onClick={() => handleClick(openGroupModal)}>建立觀察組合</button>
-          <div style={{ marginTop: 8, textAlign: 'left' }}>
-            <label>
-              預計月報酬：
-              <input
-                type="number"
-                value={monthlyIncomeGoal}
-                onChange={e => setMonthlyIncomeGoal(Number(e.target.value) || 0)}
-                style={{ width: 80, marginLeft: 4 }}
-              />
-            </label>
-          </div>
-        </>
-      )}
+      <button onClick={() => handleClick(openGroupModal)}>建立觀察組合</button>
+      <div style={{ marginTop: 8, textAlign: 'left' }}>
+        <label>
+          預計月報酬：
+          <input
+            type="number"
+            value={monthlyIncomeGoal}
+            onChange={e => setMonthlyIncomeGoal(Number(e.target.value) || 0)}
+            style={{ width: 80, marginLeft: 4 }}
+          />
+        </label>
+      </div>
     </div>
   );
 }

--- a/src/components/DisplayDropdown.jsx
+++ b/src/components/DisplayDropdown.jsx
@@ -2,8 +2,6 @@ import { useRef } from 'react';
 import useClickOutside from './useClickOutside';
 
 export default function DisplayDropdown({
-  toggleCalendar,
-  showCalendar,
   toggleDiamond,
   showDiamondOnly,
   toggleDividendYield,
@@ -22,22 +20,15 @@ export default function DisplayDropdown({
 
   return (
     <div className="action-dropdown" ref={ref}>
-      <button onClick={() => handleClick(toggleCalendar)}>
-        {showCalendar ? '顯示表格' : '顯示月曆'}
+      <button onClick={() => handleClick(toggleDiamond)}>
+        {showDiamondOnly ? '顯示全部' : '顯示鑽石'}
       </button>
-      {!showCalendar && (
-        <>
-          <button onClick={() => handleClick(toggleDiamond)}>
-            {showDiamondOnly ? '顯示全部' : '顯示鑽石'}
-          </button>
-          <button onClick={() => handleClick(toggleDividendYield)}>
-            {showDividendYield ? '顯示配息' : '顯示殖利率'}
-          </button>
-          <button onClick={() => handleClick(toggleAxis)}>
-            {showInfoAxis ? '顯示月份' : '顯示資訊'}
-          </button>
-        </>
-      )}
+      <button onClick={() => handleClick(toggleDividendYield)}>
+        {showDividendYield ? '顯示配息' : '顯示殖利率'}
+      </button>
+      <button onClick={() => handleClick(toggleAxis)}>
+        {showInfoAxis ? '顯示月份' : '顯示資訊'}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix site logo overflowing its container on small screens
- show calendar and table together with toggleable calendar section
- drop calendar/table items from display options and reposition display dropdown

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfc3c678288329b06775308c02ade9