### PR TITLE
Move more functions button next to year selector

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -604,19 +604,6 @@ button:active {
   gap: 4px;
 }
 
-.more-group {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .more-item {
   position: relative;
-}
-
-@media (max-width: 576px) {
-  .more-group {
-    width: 100%;
-    justify-content: center;
-  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -571,17 +571,6 @@ function App() {
                   <option value={year} key={year}>{year}</option>
                 ))}
               </select>
-            </div>
-            <div className="control-pair">
-              <label>觀察組合：</label>
-              <select value={selectedGroup} onChange={handleGroupChange}>
-                <option value="">自選</option>
-                {watchGroups.map(g => (
-                  <option key={g.name} value={g.name}>{g.name}</option>
-                ))}
-              </select>
-            </div>
-            <div className="more-group">
               <div className="more-item">
                 <button onClick={() => setShowActions(v => !v)}>更多功能</button>
                 {showActions && (
@@ -593,6 +582,15 @@ function App() {
                   />
                 )}
               </div>
+            </div>
+            <div className="control-pair">
+              <label>觀察組合：</label>
+              <select value={selectedGroup} onChange={handleGroupChange}>
+                <option value="">自選</option>
+                {watchGroups.map(g => (
+                  <option key={g.name} value={g.name}>{g.name}</option>
+                ))}
+              </select>
             </div>
           </div>
           <button onClick={() => setShowCalendar(v => !v)} style={{ marginTop: 10 }}>


### PR DESCRIPTION
## Summary
- Show dividend table's "更多功能" button beside the year selector
- Clean up related styles

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bff296218883299214834c5b146a58