### PR TITLE
style: restyle hide calendar toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -593,7 +593,11 @@ function App() {
               </select>
             </div>
           </div>
-          <button onClick={() => setShowCalendar(v => !v)} style={{ marginTop: 10 }}>
+          <button
+            className="more-btn"
+            onClick={() => setShowCalendar(v => !v)}
+            style={{ marginTop: 10 }}
+          >
             {showCalendar ? '隱藏月曆' : '顯示月曆'}
           </button>
 

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -192,7 +192,10 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                 <h3>{selectedYear} 配息總覽</h3>
             </div>
             <div style={{ margin: '10px 0' }}>
-                <button onClick={() => setShowCalendar(v => !v)}>
+                <button
+                    className="more-btn"
+                    onClick={() => setShowCalendar(v => !v)}
+                >
                     {showCalendar ? '隱藏月曆' : '顯示月曆'}
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- restyle the calendar visibility toggle using link-style `more-btn`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c02a1a9810832985cbb097b0191121