### PR TITLE
Rename more display menu and move diamond filter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,8 +60,6 @@ function App() {
   // Filter which event types to show on calendar
   const [calendarFilter, setCalendarFilter] = useState('ex');
 
-  // Filter to show only rows with diamond
-  const [showDiamondOnly, setShowDiamondOnly] = useState(false);
   // Toggle between showing dividend or dividend yield
   const [showDividendYield, setShowDividendYield] = useState(false);
   // Toggle axis between months and info categories
@@ -71,7 +69,7 @@ function App() {
 
     // Multi-select filters
     const [selectedStockIds, setSelectedStockIds] = useState([]);
-    const [extraFilters, setExtraFilters] = useState({ minYield: '', freq: [], upcomingWithin: '' });
+    const [extraFilters, setExtraFilters] = useState({ minYield: '', freq: [], upcomingWithin: '', diamond: false });
 
   // Watch groups
   const [watchGroups, setWatchGroups] = useState([]);
@@ -102,9 +100,8 @@ function App() {
   const handleResetFilters = (keepIds = false) => {
       if (!keepIds) setSelectedStockIds([]);
       setMonthHasValue(Array(12).fill(false));
-      setShowDiamondOnly(false);
       setShowAllStocks(false);
-      setExtraFilters({ minYield: '', freq: [], upcomingWithin: '' });
+      setExtraFilters({ minYield: '', freq: [], upcomingWithin: '', diamond: false });
   };
 
   useEffect(() => {
@@ -399,7 +396,7 @@ function App() {
     });
   };
 
-  const displayStocks = showDiamondOnly
+  const displayStocks = extraFilters.diamond
     ? filteredStocks.filter(stock => {
         for (let m = 0; m < 12; m++) {
           const cell = dividendTable[stock.stock_id]?.[m];
@@ -621,11 +618,9 @@ function App() {
               )}
 
               <div className="more-item" style={{ marginTop: 10 }}>
-                <button onClick={() => setShowDisplays(v => !v)}>更多顯示</button>
+                <button onClick={() => setShowDisplays(v => !v)}>其他顯示</button>
                 {showDisplays && (
                   <DisplayDropdown
-                    toggleDiamond={() => setShowDiamondOnly(v => !v)}
-                    showDiamondOnly={showDiamondOnly}
                     toggleDividendYield={() => setShowDividendYield(v => !v)}
                     showDividendYield={showDividendYield}
                     toggleAxis={() => setShowInfoAxis(v => !v)}

--- a/src/components/AdvancedFilterDropdown.jsx
+++ b/src/components/AdvancedFilterDropdown.jsx
@@ -15,7 +15,7 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
   };
 
   const handleClear = () => {
-    setTemp({ minYield: '', freq: [], upcomingWithin: '' });
+    setTemp({ minYield: '', freq: [], upcomingWithin: '', diamond: false });
   };
 
   const handleApply = () => {
@@ -47,6 +47,16 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
             /> {opt.l}
           </label>
         ))}
+      </div>
+      <hr />
+      <div className="dropdown-section">
+        <label className="dropdown-item">
+          <input
+            type="checkbox"
+            checked={temp.diamond}
+            onChange={e => setTemp({ ...temp, diamond: e.target.checked })}
+          /> 只顯示鑽石
+        </label>
       </div>
       <hr />
       <div className="dropdown-section">

--- a/src/components/DisplayDropdown.jsx
+++ b/src/components/DisplayDropdown.jsx
@@ -2,8 +2,6 @@ import { useRef } from 'react';
 import useClickOutside from './useClickOutside';
 
 export default function DisplayDropdown({
-  toggleDiamond,
-  showDiamondOnly,
   toggleDividendYield,
   showDividendYield,
   toggleAxis,
@@ -19,16 +17,13 @@ export default function DisplayDropdown({
   };
 
   return (
-    <div className="action-dropdown" ref={ref}>
-      <button onClick={() => handleClick(toggleDiamond)}>
-        {showDiamondOnly ? '顯示全部' : '顯示鑽石'}
-      </button>
-      <button onClick={() => handleClick(toggleDividendYield)}>
-        {showDividendYield ? '顯示配息' : '顯示殖利率'}
-      </button>
-      <button onClick={() => handleClick(toggleAxis)}>
-        {showInfoAxis ? '顯示月份' : '顯示資訊'}
-      </button>
-    </div>
+      <div className="action-dropdown" ref={ref}>
+        <button onClick={() => handleClick(toggleDividendYield)}>
+          {showDividendYield ? '顯示配息' : '顯示殖利率'}
+        </button>
+        <button onClick={() => handleClick(toggleAxis)}>
+          {showInfoAxis ? '顯示月份' : '顯示資訊'}
+        </button>
+      </div>
   );
 }


### PR DESCRIPTION
## Summary
- rename "更多顯示" button to "其他顯示"
- move diamond-only view into advanced filters
- remove diamond option from display dropdown

## Testing
- `pnpm test` *(fails: Cannot use 'import.meta' outside a module; InventoryTab interactions test)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04c17ebec8329a76fff6b8ef9ffd0