### PR TITLE
Ensure UTF-8 encoding for CSV import/export

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -40,7 +40,7 @@ export default function InventoryTab() {
       item.price ?? ''
     ]);
     const csv = [header, ...rows].map(r => r.join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const blob = new Blob(['\ufeff', csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -82,7 +82,7 @@ export default function InventoryTab() {
       alert('已匯入完成');
       if (typeof window !== 'undefined') window.location.reload();
     };
-    reader.readAsText(file);
+    reader.readAsText(file, 'utf-8');
   };
 
   const handleImportClick = () => {

--- a/src/googleDrive.js
+++ b/src/googleDrive.js
@@ -47,14 +47,14 @@ function toCsv(list) {
     item.type,
     item.price ?? ''
   ]);
-  return [header, ...rows].map(r => r.join(',')).join('\n');
+  return '\ufeff' + [header, ...rows].map(r => r.join(',')).join('\n');
 }
 
 export async function exportTransactionsToDrive(list) {
   await initDrive();
   await ensureSignedIn();
   const csv = toCsv(list);
-  const file = new Blob([csv], { type: 'text/csv' });
+  const file = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const metadata = { name: 'inventory_backup.csv', mimeType: 'text/csv' };
   const accessToken = window.gapi.auth.getToken().access_token;
   const form = new FormData();


### PR DESCRIPTION
## Summary
- prepend UTF-8 BOM when exporting CSV backups to keep Chinese characters readable
- explicitly read imported CSV files as UTF-8
- include BOM and UTF-8 MIME type in Google Drive exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d06e507c8329bdf80b51c758b3fb