### PR TITLE
Look up stock names dynamically

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -1,4 +1,3 @@
-/* global process */
 import { useState, useEffect, useRef, useCallback } from 'react';
 import Cookies from 'js-cookie';
 import { API_HOST } from './config';
@@ -238,7 +237,7 @@ export default function InventoryTab() {
       const s = stockList.find(x => x.stock_id === item.stock_id) || {};
       inventoryMap[item.stock_id] = {
         stock_id: item.stock_id,
-        stock_name: s.stock_name || item.stock_name || '',
+        stock_name: s.stock_name || '',
         total_quantity: 0,
         total_cost: 0
       };
@@ -277,7 +276,7 @@ export default function InventoryTab() {
     setTransactionHistory([
       ...transactionHistory,
       {
-        ...form,
+        stock_id: form.stock_id,
         date: form.date,
         quantity: Number(form.quantity),
         price: Number(form.price),
@@ -321,7 +320,7 @@ export default function InventoryTab() {
     }
     setTransactionHistory([
       ...transactionHistory,
-      { stock_id, stock_name: stock.stock_name, date: getToday(), quantity: Number(qty), type: 'sell' }
+      { stock_id, date: getToday(), quantity: Number(qty), type: 'sell' }
     ]);
     setSellModal({ show: false, stock: null });
   };

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -40,7 +40,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const holdingIds = Array.from(stockIdSet).filter(id => getHolding(id, `${selectedYear}-12-31`) > 0);
     const holdingIdSet = new Set(holdingIds);
 
-    // 建立股票代號到名稱的對應
+    // 建立股票代號到名稱的對應（名稱由 tw_stock_id 提供）
     const stockMap = {};
     holdingIds.forEach(id => {
         const info = (allDividendData || []).find(d => d.stock_id === id);

--- a/src/UserDividendsTab.test.jsx
+++ b/src/UserDividendsTab.test.jsx
@@ -1,0 +1,20 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import UserDividendsTab from './UserDividendsTab';
+import { readTransactionHistory } from './transactionStorage';
+
+jest.mock('./transactionStorage');
+jest.mock('./components/DividendCalendar', () => () => null);
+
+test('displays stock id and dynamic name from dividend data', async () => {
+  readTransactionHistory.mockReturnValue([
+    { stock_id: '0050', date: '2024-01-01', quantity: 1000, type: 'buy' }
+  ]);
+
+  const allDividendData = [
+    { stock_id: '0050', stock_name: 'Test ETF' }
+  ];
+
+  render(<UserDividendsTab allDividendData={allDividendData} selectedYear={2024} />);
+  expect(await screen.findByText('0050 Test ETF')).toBeInTheDocument();
+});

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -21,7 +21,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
             transactionHistory.map((item, idx) => {
               const stock = stockList.find(s => s.stock_id === item.stock_id) || {};
               const isEditing = editingIdx === idx;
-              const name = item.stock_name || stock.stock_name || '';
+              const name = stock.stock_name || '';
               return (
                 <tr key={idx}>
                   <td className="stock-col">

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,2 @@
+/* global process */
 export const API_HOST = (typeof process !== 'undefined' && process.env?.VITE_API_HOST) || '';


### PR DESCRIPTION
## Summary
- Reference stock names via tw_stock_id data instead of saving them with transactions
- Ensure dividends tab and transaction history table resolve names from stock codes
- Test dividends tab displays dynamic name

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0fdb2d3c08329a1bf36d579c7ce47