### PR TITLE
Preserve leading zeros when exporting stock codes

### DIFF
--- a/src/csvUtils.js
+++ b/src/csvUtils.js
@@ -1,0 +1,14 @@
+export function encodeCsvCode(code) {
+  return `="${code}"`;
+}
+
+export function decodeCsvCode(raw) {
+  const trimmed = String(raw).trim();
+  if (trimmed.startsWith('="') && trimmed.endsWith('"')) {
+    return trimmed.slice(2, -1);
+  }
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}

--- a/src/csvUtils.test.js
+++ b/src/csvUtils.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import { encodeCsvCode, decodeCsvCode } from './csvUtils';
+
+test('encodeCsvCode wraps code with formula to preserve leading zeros', () => {
+  expect(encodeCsvCode('00878')).toBe('="00878"');
+});
+
+test('decodeCsvCode removes wrapper and returns original code', () => {
+  expect(decodeCsvCode('="00878"')).toBe('00878');
+  expect(decodeCsvCode('00878')).toBe('00878');
+});

--- a/src/googleDrive.js
+++ b/src/googleDrive.js
@@ -1,3 +1,5 @@
+import { encodeCsvCode, decodeCsvCode } from './csvUtils';
+
 const CLIENT_ID = typeof window !== 'undefined' && window.GOOGLE_CLIENT_ID ? window.GOOGLE_CLIENT_ID : '';
 const API_KEY = typeof window !== 'undefined' && window.GOOGLE_API_KEY ? window.GOOGLE_API_KEY : '';
 const SCOPES = 'https://www.googleapis.com/auth/drive.file';
@@ -40,14 +42,14 @@ async function ensureSignedIn() {
 
 function toCsv(codes) {
   const header = ['stock_id'];
-  return '\ufeff' + [header.join(','), ...codes].join('\n');
+  return '\ufeff' + [header.join(','), ...codes.map(encodeCsvCode)].join('\n');
 }
 
 function fromCsv(text) {
   const lines = text.trim().split(/\r?\n/);
   if (lines.length <= 1) return [];
   const [, ...rows] = lines;
-  return rows.filter(line => line.trim()).map(code => code.trim());
+  return rows.filter(line => line.trim()).map(code => decodeCsvCode(code));
 }
 
 export async function exportTransactionsToDrive(codes) {


### PR DESCRIPTION
## Summary
- Encode stock codes when exporting to CSV or Drive so numbers like `00878` remain intact
- Decode encoded stock codes when importing
- Add helper utilities and tests for CSV code encoding/decoding

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c11877aa8c8329a40477743c74167f