### PR TITLE
Include transaction history in CSV/Drive exports

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -4,7 +4,7 @@ import { API_HOST } from './config';
 import { fetchWithCache } from './api';
 import { migrateTransactionHistory, saveTransactionHistory } from './transactionStorage';
 import { exportTransactionsToDrive, importTransactionsFromDrive } from './googleDrive';
-import { encodeCsvCode, decodeCsvCode } from './csvUtils';
+import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
 import AddTransactionModal from './components/AddTransactionModal';
 import SellModal from './components/SellModal';
 import TransactionHistoryTable from './components/TransactionHistoryTable';
@@ -31,12 +31,8 @@ export default function InventoryTab() {
   const [latestPrices, setLatestPrices] = useState({});
 
   const handleExport = useCallback(() => {
-    const header = ['stock_id'];
-    const rows = Array.from(
-      new Set(transactionHistory.map(item => encodeCsvCode(item.stock_id)))
-    );
-    const csv = [header.join(','), ...rows].join('\n');
-    const blob = new Blob(['\ufeff', csv], { type: 'text/csv;charset=utf-8;' });
+    const csv = transactionsToCsv(transactionHistory);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -52,18 +48,11 @@ export default function InventoryTab() {
     const reader = new FileReader();
     reader.onload = event => {
       const text = event.target.result;
-      const lines = text.trim().split(/\r?\n/);
-      if (lines.length <= 1) return;
-      const [, ...rows] = lines;
-      const list = rows
-        .filter(line => line.trim())
-        .map(code => ({
-          stock_id: decodeCsvCode(code),
-          date: getToday(),
-          quantity: 0,
-          type: 'buy',
-          price: ''
-        }));
+      const list = transactionsFromCsv(text);
+      if (list.length === 0) {
+        e.target.value = '';
+        return;
+      }
       if (transactionHistory.length > 0) {
         if (!window.confirm('匯入後將覆蓋現有紀錄，是否繼續？')) {
           e.target.value = '';
@@ -94,8 +83,7 @@ export default function InventoryTab() {
   const handleDriveExport = async () => {
     if (!window.confirm('確定要匯出到 Google Drive？')) return;
     try {
-      const codes = Array.from(new Set(transactionHistory.map(item => item.stock_id)));
-      await exportTransactionsToDrive(codes);
+      await exportTransactionsToDrive(transactionHistory);
       Cookies.set(BACKUP_COOKIE_KEY, new Date().toISOString(), { expires: 365 });
       alert('已匯出到 Google Drive');
     } catch (err) {
@@ -106,18 +94,11 @@ export default function InventoryTab() {
 
   const handleDriveImport = async () => {
     try {
-      const codes = await importTransactionsFromDrive();
-      if (!codes || codes.length === 0) {
+      const list = await importTransactionsFromDrive();
+      if (!list || list.length === 0) {
         alert('未找到備份檔案');
         return;
       }
-      const list = codes.map(code => ({
-        stock_id: code,
-        date: getToday(),
-        quantity: 0,
-        type: 'buy',
-        price: ''
-      }));
       if (transactionHistory.length > 0) {
         if (!window.confirm('匯入後將覆蓋現有紀錄，是否繼續？')) {
           return;

--- a/src/csvUtils.js
+++ b/src/csvUtils.js
@@ -12,3 +12,31 @@ export function decodeCsvCode(raw) {
   }
   return trimmed;
 }
+
+export function transactionsToCsv(list) {
+  const header = ['stock_id', 'date', 'quantity', 'price', 'type'];
+  const rows = list.map(item => [
+    encodeCsvCode(item.stock_id),
+    item.date,
+    item.quantity,
+    item.price ?? '',
+    item.type
+  ].join(','));
+  return '\ufeff' + [header.join(','), ...rows].join('\n');
+}
+
+export function transactionsFromCsv(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length <= 1) return [];
+  const [, ...rows] = lines;
+  return rows.filter(line => line.trim()).map(line => {
+    const [stock_id, date, quantity, price, type] = line.split(',');
+    return {
+      stock_id: decodeCsvCode(stock_id),
+      date,
+      quantity: Number(quantity),
+      price: price ? Number(price) : '',
+      type
+    };
+  });
+}

--- a/src/csvUtils.test.js
+++ b/src/csvUtils.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import { encodeCsvCode, decodeCsvCode } from './csvUtils';
+import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
 
 test('encodeCsvCode wraps code with formula to preserve leading zeros', () => {
   expect(encodeCsvCode('00878')).toBe('="00878"');
@@ -8,4 +9,17 @@ test('encodeCsvCode wraps code with formula to preserve leading zeros', () => {
 test('decodeCsvCode removes wrapper and returns original code', () => {
   expect(decodeCsvCode('="00878"')).toBe('00878');
   expect(decodeCsvCode('00878')).toBe('00878');
+});
+
+test('transactionsToCsv and transactionsFromCsv round-trip transactions', () => {
+  const list = [
+    { stock_id: '0050', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
+    { stock_id: '0056', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
+  ];
+  const csv = transactionsToCsv(list);
+  const parsed = transactionsFromCsv(csv);
+  expect(parsed).toEqual([
+    { stock_id: '0050', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
+    { stock_id: '0056', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
+  ]);
 });

--- a/src/googleDrive.js
+++ b/src/googleDrive.js
@@ -1,4 +1,4 @@
-import { encodeCsvCode, decodeCsvCode } from './csvUtils';
+import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
 
 const CLIENT_ID = typeof window !== 'undefined' && window.GOOGLE_CLIENT_ID ? window.GOOGLE_CLIENT_ID : '';
 const API_KEY = typeof window !== 'undefined' && window.GOOGLE_API_KEY ? window.GOOGLE_API_KEY : '';
@@ -40,22 +40,10 @@ async function ensureSignedIn() {
   }
 }
 
-function toCsv(codes) {
-  const header = ['stock_id'];
-  return '\ufeff' + [header.join(','), ...codes.map(encodeCsvCode)].join('\n');
-}
-
-function fromCsv(text) {
-  const lines = text.trim().split(/\r?\n/);
-  if (lines.length <= 1) return [];
-  const [, ...rows] = lines;
-  return rows.filter(line => line.trim()).map(code => decodeCsvCode(code));
-}
-
-export async function exportTransactionsToDrive(codes) {
+export async function exportTransactionsToDrive(list) {
   await initDrive();
   await ensureSignedIn();
-  const csv = toCsv(codes);
+  const csv = transactionsToCsv(list);
   const file = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const metadata = { name: 'inventory_backup.csv', mimeType: 'text/csv' };
   const accessToken = window.gapi.auth.getToken().access_token;
@@ -79,5 +67,5 @@ export async function importTransactionsFromDrive() {
   if (!list.result.files || list.result.files.length === 0) return null;
   const fileId = list.result.files[0].id;
   const file = await window.gapi.client.drive.files.get({ fileId, alt: 'media' });
-  return fromCsv(file.body);
+  return transactionsFromCsv(file.body);
 }


### PR DESCRIPTION
## Summary
- Export full transaction history (stock id, date, quantity, price, type) to CSV and Google Drive
- Import full transaction history from CSV and Google Drive
- Add utilities and tests for CSV <-> transaction conversions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1476585b48329aa1323e7f4f88763