### PR TITLE
Fix missing stock names after CSV import

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -48,8 +48,14 @@ export default function InventoryTab() {
     const reader = new FileReader();
     reader.onload = event => {
       const text = event.target.result;
-      const list = transactionsFromCsv(text);
-      if (list.length === 0) {
+      const imported = transactionsFromCsv(text).map(item => {
+        const stock = stockList.find(s => s.stock_id === item.stock_id);
+        return {
+          ...item,
+          stock_name: stock ? stock.stock_name : item.stock_name || ''
+        };
+      });
+      if (imported.length === 0) {
         e.target.value = '';
         return;
       }
@@ -59,8 +65,8 @@ export default function InventoryTab() {
           return;
         }
       }
-      setTransactionHistory(list);
-      saveTransactionHistory(list);
+      setTransactionHistory(imported);
+      saveTransactionHistory(imported);
       e.target.value = '';
       alert('已匯入完成');
       if (typeof window !== 'undefined') window.location.reload();
@@ -104,8 +110,15 @@ export default function InventoryTab() {
           return;
         }
       }
-      setTransactionHistory(list);
-      saveTransactionHistory(list);
+      const enriched = list.map(item => {
+        const stock = stockList.find(s => s.stock_id === item.stock_id);
+        return {
+          ...item,
+          stock_name: item.stock_name || (stock ? stock.stock_name : '')
+        };
+      });
+      setTransactionHistory(enriched);
+      saveTransactionHistory(enriched);
       alert('已從 Google Drive 匯入資料');
       if (typeof window !== 'undefined') window.location.reload();
     } catch (err) {
@@ -207,7 +220,7 @@ export default function InventoryTab() {
       const s = stockList.find(x => x.stock_id === item.stock_id) || {};
       inventoryMap[item.stock_id] = {
         stock_id: item.stock_id,
-        stock_name: s.stock_name || '',
+        stock_name: s.stock_name || item.stock_name || '',
         total_quantity: 0,
         total_cost: 0
       };
@@ -247,6 +260,7 @@ export default function InventoryTab() {
       ...transactionHistory,
       {
         stock_id: form.stock_id,
+        stock_name: form.stock_name,
         date: form.date,
         quantity: Number(form.quantity),
         price: Number(form.price),
@@ -290,7 +304,7 @@ export default function InventoryTab() {
     }
     setTransactionHistory([
       ...transactionHistory,
-      { stock_id, date: getToday(), quantity: Number(qty), type: 'sell' }
+      { stock_id, stock_name: stock.stock_name, date: getToday(), quantity: Number(qty), type: 'sell' }
     ]);
     setSellModal({ show: false, stock: null });
   };

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -21,7 +21,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
             transactionHistory.map((item, idx) => {
               const stock = stockList.find(s => s.stock_id === item.stock_id) || {};
               const isEditing = editingIdx === idx;
-              const name = stock.stock_name || '';
+              const name = stock.stock_name || item.stock_name || '';
               return (
                 <tr key={idx}>
                   <td className="stock-col">

--- a/src/csvUtils.js
+++ b/src/csvUtils.js
@@ -14,25 +14,41 @@ export function decodeCsvCode(raw) {
 }
 
 export function transactionsToCsv(list) {
-  const header = ['stock_id', 'date', 'quantity', 'price', 'type'];
+  const header = ['stock_id', 'stock_name', 'date', 'quantity', 'price', 'type'];
   const rows = list.map(item => [
     encodeCsvCode(item.stock_id),
+    item.stock_name || '',
     item.date,
     item.quantity,
     item.price ?? '',
     item.type
   ].join(','));
-  return '\ufeff' + [header.join(','), ...rows].join('\n');
+  return '﻿' + [header.join(','), ...rows].join('\n');
 }
 
 export function transactionsFromCsv(text) {
   const lines = text.trim().split(/\r?\n/);
   if (lines.length <= 1) return [];
-  const [, ...rows] = lines;
+  const header = lines[0].split(',');
+  const hasName = header.includes('stock_name');
+  const rows = lines.slice(1);
   return rows.filter(line => line.trim()).map(line => {
-    const [stock_id, date, quantity, price, type] = line.split(',');
+    const parts = line.split(',');
+    if (hasName) {
+      const [stock_id, stock_name, date, quantity, price, type] = parts;
+      return {
+        stock_id: decodeCsvCode(stock_id),
+        stock_name: stock_name || '',
+        date,
+        quantity: Number(quantity),
+        price: price ? Number(price) : '',
+        type
+      };
+    }
+    const [stock_id, date, quantity, price, type] = parts;
     return {
       stock_id: decodeCsvCode(stock_id),
+      stock_name: '',
       date,
       quantity: Number(quantity),
       price: price ? Number(price) : '',

--- a/src/csvUtils.test.js
+++ b/src/csvUtils.test.js
@@ -13,13 +13,13 @@ test('decodeCsvCode removes wrapper and returns original code', () => {
 
 test('transactionsToCsv and transactionsFromCsv round-trip transactions', () => {
   const list = [
-    { stock_id: '0050', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
-    { stock_id: '0056', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
+    { stock_id: '0050', stock_name: 'ETF A', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
+    { stock_id: '0056', stock_name: 'ETF B', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
   ];
   const csv = transactionsToCsv(list);
   const parsed = transactionsFromCsv(csv);
   expect(parsed).toEqual([
-    { stock_id: '0050', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
-    { stock_id: '0056', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
+    { stock_id: '0050', stock_name: 'ETF A', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
+    { stock_id: '0056', stock_name: 'ETF B', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
   ]);
 });


### PR DESCRIPTION
## Summary
- store `stock_name` on imported or added transactions
- show names from stored transactions when stock list is unavailable
- include `stock_name` column in CSV import/export

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1570c2da48329945e0c4e04e9e1ea