### PR TITLE
Fix missing stock names after CSV import

### DIFF
--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -21,7 +21,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
             transactionHistory.map((item, idx) => {
               const stock = stockList.find(s => s.stock_id === item.stock_id) || {};
               const isEditing = editingIdx === idx;
-              const name = stock.stock_name || '';
+              const name = stock.stock_name || item.stock_name || '';
               return (
                 <tr key={idx}>
                   <td className="stock-col">

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,4 @@
 /* global process */
-export const API_HOST = (typeof process !== 'undefined' && process.env?.VITE_API_HOST) || '';
+export const API_HOST =
+  (typeof process !== 'undefined' && process.env?.VITE_API_HOST) ||
+  'https://api.etflife.org';

--- a/src/csvUtils.js
+++ b/src/csvUtils.js
@@ -14,25 +14,41 @@ export function decodeCsvCode(raw) {
 }
 
 export function transactionsToCsv(list) {
-  const header = ['stock_id', 'date', 'quantity', 'price', 'type'];
+  const header = ['stock_id', 'stock_name', 'date', 'quantity', 'price', 'type'];
   const rows = list.map(item => [
     encodeCsvCode(item.stock_id),
+    item.stock_name || '',
     item.date,
     item.quantity,
     item.price ?? '',
     item.type
   ].join(','));
-  return '\ufeff' + [header.join(','), ...rows].join('\n');
+  return '﻿' + [header.join(','), ...rows].join('\n');
 }
 
 export function transactionsFromCsv(text) {
   const lines = text.trim().split(/\r?\n/);
   if (lines.length <= 1) return [];
-  const [, ...rows] = lines;
+  const header = lines[0].split(',');
+  const hasName = header.includes('stock_name');
+  const rows = lines.slice(1);
   return rows.filter(line => line.trim()).map(line => {
-    const [stock_id, date, quantity, price, type] = line.split(',');
+    const parts = line.split(',');
+    if (hasName) {
+      const [stock_id, stock_name, date, quantity, price, type] = parts;
+      return {
+        stock_id: decodeCsvCode(stock_id),
+        stock_name: stock_name || '',
+        date,
+        quantity: Number(quantity),
+        price: price ? Number(price) : '',
+        type
+      };
+    }
+    const [stock_id, date, quantity, price, type] = parts;
     return {
       stock_id: decodeCsvCode(stock_id),
+      stock_name: '',
       date,
       quantity: Number(quantity),
       price: price ? Number(price) : '',

--- a/src/csvUtils.test.js
+++ b/src/csvUtils.test.js
@@ -13,13 +13,13 @@ test('decodeCsvCode removes wrapper and returns original code', () => {
 
 test('transactionsToCsv and transactionsFromCsv round-trip transactions', () => {
   const list = [
-    { stock_id: '0050', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
-    { stock_id: '0056', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
+    { stock_id: '0050', stock_name: 'ETF A', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
+    { stock_id: '0056', stock_name: 'ETF B', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
   ];
   const csv = transactionsToCsv(list);
   const parsed = transactionsFromCsv(csv);
   expect(parsed).toEqual([
-    { stock_id: '0050', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
-    { stock_id: '0056', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
+    { stock_id: '0050', stock_name: 'ETF A', date: '2024-01-01', quantity: 1000, price: 10, type: 'buy' },
+    { stock_id: '0056', stock_name: 'ETF B', date: '2024-02-01', quantity: 500, price: '', type: 'sell' }
   ]);
 });


### PR DESCRIPTION
## Summary
- store `stock_name` on imported or added transactions
- show names from stored transactions when stock list is unavailable
- include `stock_name` column in CSV import/export
- default API host to `https://api.etflife.org` and backfill missing names using the fetched list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1570c2da48329945e0c4e04e9e1ea