### PR TITLE
Handle dividend API failures with stale cache fallback

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -50,5 +50,20 @@ describe('fetchWithCache', () => {
     expect(result.cacheStatus).toBe('fresh');
     expect(result.timestamp).toBe(new Date('2024-01-01T02:01:00Z').toISOString());
   });
+
+  test('falls back to stale cache on fetch error', async () => {
+    jest.useFakeTimers();
+    const timestamp = new Date('2024-01-01T00:00:00Z').toISOString();
+    jest.setSystemTime(new Date('2024-01-01T03:00:00Z'));
+    localStorage.setItem(cacheKey, JSON.stringify({ value: 1 }));
+    localStorage.setItem(metaKey, JSON.stringify({ timestamp }));
+
+    globalThis.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    const result = await fetchWithCache(URL);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ data: { value: 1 }, cacheStatus: 'stale', timestamp });
+  });
 });
 


### PR DESCRIPTION
## Summary
- Return cached dividend data when network errors or non-200 responses occur
- Test fetchWithCache to ensure stale cache is used on fetch failures

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1726946dc8329bef6705596096e32