### PR TITLE
feat: cache site stats

### DIFF
--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { API_HOST } from './config';
+import { fetchWithCache } from './api';
 
 export default function HomeTab() {
   const [stats, setStats] = useState({ milestones: [], latest: [], tip: '' });
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API_HOST}/site_stats`)
-      .then(res => res.json())
-      .then(data => {
+    fetchWithCache(`${API_HOST}/site_stats`, 4 * 60 * 60 * 1000)
+      .then(({ data }) => {
         if (!cancelled) {
           setStats({
             milestones: Array.isArray(data?.milestones) ? data.milestones : [],

--- a/src/HomeTab.test.jsx
+++ b/src/HomeTab.test.jsx
@@ -1,6 +1,12 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import HomeTab from './HomeTab';
+import { fetchWithCache } from './api';
+
+jest.mock('./api');
+jest.mock('./config', () => ({
+  API_HOST: 'http://localhost'
+}));
 
 const mockData = {
   milestones: [
@@ -16,9 +22,7 @@ const mockData = {
 };
 
 beforeEach(() => {
-  globalThis.fetch = jest.fn().mockResolvedValue({
-    json: jest.fn().mockResolvedValue(mockData)
-  });
+  fetchWithCache.mockResolvedValue({ data: mockData });
 });
 
 afterEach(() => {

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
-export async function fetchWithCache(url) {
-  const MAX_AGE = 2 * 60 * 60 * 1000; // 2 hours
+export async function fetchWithCache(url, maxAge = 2 * 60 * 60 * 1000) {
+  // maxAge controls how long to reuse cached data before revalidating
   const cacheKey = `cache:data:${url}`;
   const metaKey = `cache:meta:${url}`;
   const headers = {};
@@ -12,7 +12,7 @@ export async function fetchWithCache(url) {
       meta = JSON.parse(metaRaw);
       if (meta.timestamp) {
         age = Date.now() - new Date(meta.timestamp).getTime();
-        if (age < MAX_AGE) {
+        if (age < maxAge) {
           const cached = localStorage.getItem(cacheKey);
           if (cached) {
             return { data: JSON.parse(cached), cacheStatus: 'cached', timestamp: meta.timestamp };
@@ -24,9 +24,9 @@ export async function fetchWithCache(url) {
     // ignore parse errors
   }
 
-  if (meta?.etag && age < MAX_AGE) {
+  if (meta?.etag && age < maxAge) {
     headers['If-None-Match'] = meta.etag;
-  } else if (meta?.lastModified && age < MAX_AGE) {
+  } else if (meta?.lastModified && age < maxAge) {
     headers['If-Modified-Since'] = meta.lastModified;
   }
 


### PR DESCRIPTION
## Summary
- cache site stats for 4 hours using local storage
- support custom cache lifetimes via `fetchWithCache`
- adjust HomeTab tests to mock cached API calls

## Testing
- `pnpm test` *(fails: command not found)*
- `pnpm lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c17b5d2dac83299999b7b214c38e4e