### PR TITLE
Add Dropbox backup import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## Dropbox Backup
+
+To enable Dropbox import and export, add your app key to a `.env` file in the project root:
+
+```
+VITE_DROPBOX_APP_KEY=your_app_key
+```
+
+Restart the development server after updating the file. The application will prompt for Dropbox authorization when using the data menu to import or export.
+
 ## Copyright
 
 © 2025 GiantBean. All rights reserved.

--- a/index.html
+++ b/index.html
@@ -20,10 +20,11 @@
         document.documentElement.setAttribute('data-theme', savedTheme);
       }
     </script>
-    <script>
-      window.GOOGLE_CLIENT_ID = '%VITE_GOOGLE_CLIENT_ID%';
-      window.GOOGLE_API_KEY = '%VITE_GOOGLE_API_KEY%';
-    </script>
+      <script>
+        window.GOOGLE_CLIENT_ID = '%VITE_GOOGLE_CLIENT_ID%';
+        window.GOOGLE_API_KEY = '%VITE_GOOGLE_API_KEY%';
+        window.DROPBOX_APP_KEY = '%VITE_DROPBOX_APP_KEY%';
+      </script>
     <title>Dividend Life</title>
   </head>
   <body>

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -4,6 +4,7 @@ import { API_HOST } from './config';
 import { fetchWithCache } from './api';
 import { migrateTransactionHistory, saveTransactionHistory } from './transactionStorage';
 import { exportTransactionsToDrive, importTransactionsFromDrive } from './googleDrive';
+import { exportTransactionsToDropbox, importTransactionsFromDropbox } from './dropbox';
 import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
 import AddTransactionModal from './components/AddTransactionModal';
 import SellModal from './components/SellModal';
@@ -124,6 +125,47 @@ export default function InventoryTab() {
     } catch (err) {
       console.error('Drive manual import failed', err);
       alert('匯入 Google Drive 失敗');
+    }
+  };
+
+  const handleDropboxExport = async () => {
+    if (!window.confirm('確定要匯出到 Dropbox？')) return;
+    try {
+      await exportTransactionsToDropbox(transactionHistory);
+      Cookies.set(BACKUP_COOKIE_KEY, new Date().toISOString(), { expires: 365 });
+      alert('已匯出到 Dropbox');
+    } catch (err) {
+      console.error('Dropbox manual export failed', err);
+      alert('匯出到 Dropbox 失敗');
+    }
+  };
+
+  const handleDropboxImport = async () => {
+    try {
+      const list = await importTransactionsFromDropbox();
+      if (!list || list.length === 0) {
+        alert('未找到備份檔案');
+        return;
+      }
+      if (transactionHistory.length > 0) {
+        if (!window.confirm('匯入後將覆蓋現有紀錄，是否繼續？')) {
+          return;
+        }
+      }
+      const enriched = list.map(item => {
+        const stock = stockList.find(s => s.stock_id === item.stock_id);
+        return {
+          ...item,
+          stock_name: item.stock_name || (stock ? stock.stock_name : '')
+        };
+      });
+      setTransactionHistory(enriched);
+      saveTransactionHistory(enriched);
+      alert('已從 Dropbox 匯入資料');
+      if (typeof window !== 'undefined') window.location.reload();
+    } catch (err) {
+      console.error('Dropbox manual import failed', err);
+      alert('匯入 Dropbox 失敗');
     }
   };
 
@@ -363,11 +405,17 @@ export default function InventoryTab() {
             <button className={styles.button} onClick={handleDriveExport}>
               匯出 Google Drive
             </button>
-            <button className={styles.button} onClick={handleDriveImport}>
-              匯入 Google Drive
-            </button>
-          </div>
-        )}
+              <button className={styles.button} onClick={handleDriveImport}>
+                匯入 Google Drive
+              </button>
+              <button className={styles.button} onClick={handleDropboxExport}>
+                匯出 Dropbox
+              </button>
+              <button className={styles.button} onClick={handleDropboxImport}>
+                匯入 Dropbox
+              </button>
+            </div>
+          )}
         <input
           type="file"
           accept=".csv"

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,1 @@
-/* global process */
 export const API_HOST = import.meta.env.VITE_API_HOST

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -1,0 +1,66 @@
+import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
+
+const APP_KEY = typeof window !== 'undefined' && window.DROPBOX_APP_KEY ? window.DROPBOX_APP_KEY : '';
+let dropboxInstance = null;
+let initialized = false;
+
+async function loadScript() {
+  if (document.getElementById('dropbox-sdk')) return;
+  await new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = 'dropbox-sdk';
+    script.src = 'https://unpkg.com/dropbox/dist/Dropbox-sdk.min.js';
+    script.onload = resolve;
+    script.onerror = reject;
+    document.body.appendChild(script);
+  });
+}
+
+export async function initDropbox() {
+  if (initialized) return dropboxInstance;
+  if (typeof window === 'undefined') return null;
+  if (!APP_KEY) throw new Error('Dropbox App Key missing');
+  await loadScript();
+
+  let accessToken = window.localStorage.getItem('DROPBOX_ACCESS_TOKEN');
+  const match = window.location.hash.match(/access_token=([^&]+)/);
+  if (match) {
+    accessToken = match[1];
+    window.localStorage.setItem('DROPBOX_ACCESS_TOKEN', accessToken);
+    window.location.hash = '';
+  }
+  if (!accessToken) {
+    const auth = new window.Dropbox.DropboxAuth({ clientId: APP_KEY });
+    const authUrl = await auth.getAuthenticationUrl(window.location.href);
+    window.location.href = authUrl;
+    return null;
+  }
+  dropboxInstance = new window.Dropbox.Dropbox({ accessToken });
+  initialized = true;
+  return dropboxInstance;
+}
+
+export async function exportTransactionsToDropbox(list) {
+  const dbx = await initDropbox();
+  if (!dbx) return;
+  const csv = transactionsToCsv(list);
+  await dbx.filesUpload({
+    path: '/inventory_backup.csv',
+    contents: csv,
+    mode: { '.tag': 'overwrite' }
+  });
+}
+
+export async function importTransactionsFromDropbox() {
+  const dbx = await initDropbox();
+  if (!dbx) return null;
+  try {
+    const res = await dbx.filesDownload({ path: '/inventory_backup.csv' });
+    const blob = res.result.fileBlob || res.fileBlob;
+    const text = await blob.text();
+    return transactionsFromCsv(text);
+  } catch (err) {
+    console.error('Dropbox download failed', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add Dropbox SDK helper to export and import CSV backups
- expose Dropbox app key via env and hook InventoryTab UI
- document Dropbox setup in README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c259a50488832980ca1254b3cba310