### PR TITLE
Add iCloud Drive import/export via file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ VITE_ONEDRIVE_SCOPES=Files.ReadWrite
 
 Restart the development server after updating the file. Use the data menu to authorize and transfer backups with OneDrive.
 
+## iCloud Drive Backup
+
+The application can also import and export inventory records through the browser's file
+pickers. On macOS or iOS, ensure you are signed in to iCloud and have iCloud Drive
+enabled. When choosing **匯出 iCloud Drive** the browser will ask where to save
+`inventory_backup.csv`; select iCloud Drive to store the file. Use **匯入 iCloud Drive**
+to open the picker again and select the backup file from iCloud Drive.
+
 ## Copyright
 
 © 2025 GiantBean. All rights reserved.

--- a/src/icloud.js
+++ b/src/icloud.js
@@ -1,0 +1,28 @@
+import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
+
+export async function exportTransactionsToICloud(list) {
+  if (typeof window === 'undefined' || !window.showSaveFilePicker) {
+    throw new Error('File System Access API not supported');
+  }
+  const csv = transactionsToCsv(list);
+  const handle = await window.showSaveFilePicker({
+    suggestedName: 'inventory_backup.csv',
+    types: [{ description: 'CSV Files', accept: { 'text/csv': ['.csv'] } }]
+  });
+  const writable = await handle.createWritable();
+  await writable.write(csv);
+  await writable.close();
+}
+
+export async function importTransactionsFromICloud() {
+  if (typeof window === 'undefined' || !window.showOpenFilePicker) {
+    throw new Error('File System Access API not supported');
+  }
+  const [handle] = await window.showOpenFilePicker({
+    types: [{ description: 'CSV Files', accept: { 'text/csv': ['.csv'] } }]
+  });
+  const file = await handle.getFile();
+  const text = await file.text();
+  return transactionsFromCsv(text);
+}
+


### PR DESCRIPTION
## Summary
- support manual iCloud Drive backup using browser file pickers
- add iCloud import/export buttons to inventory tab
- document iCloud Drive backup workflow

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c281f3ff3c8329a581af734ace113a