### PR TITLE
Style data access menu as dropdown

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -11,6 +11,7 @@ import { transactionsToCsv, transactionsFromCsv } from './csvUtils';
 import AddTransactionModal from './components/AddTransactionModal';
 import SellModal from './components/SellModal';
 import TransactionHistoryTable from './components/TransactionHistoryTable';
+import DataDropdown from './components/DataDropdown';
 import styles from './InventoryTab.module.css';
 
 const BACKUP_COOKIE_KEY = 'inventory_last_backup';
@@ -472,46 +473,29 @@ export default function InventoryTab() {
         >
           新增購買紀錄
         </button>
-        <button
-          className={styles.button}
-          onClick={() => setShowDataMenu(!showDataMenu)}
-        >
-          存取資料
-        </button>
-        {showDataMenu && (
-          <div className={styles.csvControls}>
-            <button className={styles.button} onClick={handleExportClick}>
-              匯出 CSV
-            </button>
-            <button className={styles.button} onClick={handleImportClick}>
-              匯入 CSV
-            </button>
-            <button className={styles.button} onClick={handleDriveExport}>
-              匯出 Google Drive
-            </button>
-              <button className={styles.button} onClick={handleDriveImport}>
-                匯入 Google Drive
-              </button>
-              <button className={styles.button} onClick={handleDropboxExport}>
-                匯出 Dropbox
-              </button>
-              <button className={styles.button} onClick={handleDropboxImport}>
-                匯入 Dropbox
-              </button>
-            <button className={styles.button} onClick={handleOneDriveExport}>
-              匯出 OneDrive
-            </button>
-            <button className={styles.button} onClick={handleOneDriveImport}>
-              匯入 OneDrive
-            </button>
-            <button className={styles.button} onClick={handleICloudExport}>
-              匯出 iCloud Drive
-            </button>
-            <button className={styles.button} onClick={handleICloudImport}>
-              匯入 iCloud Drive
-            </button>
-            </div>
+        <div className="more-item">
+          <button
+            className={styles.button}
+            onClick={() => setShowDataMenu(v => !v)}
+          >
+            存取資料
+          </button>
+          {showDataMenu && (
+            <DataDropdown
+              onClose={() => setShowDataMenu(false)}
+              handleImportClick={handleImportClick}
+              handleExportClick={handleExportClick}
+              handleDriveImport={handleDriveImport}
+              handleDriveExport={handleDriveExport}
+              handleDropboxImport={handleDropboxImport}
+              handleDropboxExport={handleDropboxExport}
+              handleOneDriveImport={handleOneDriveImport}
+              handleOneDriveExport={handleOneDriveExport}
+              handleICloudImport={handleICloudImport}
+              handleICloudExport={handleICloudExport}
+            />
           )}
+        </div>
         <input
           type="file"
           accept=".csv"

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -23,9 +23,19 @@
   flex-wrap: wrap;
 }
 
-.csvControls {
+
+.dataDropdown button {
+  display: inline-block;
+  width: auto;
+  margin: 0 0 0 4px;
+  text-align: center;
+}
+
+.dataRow {
   display: flex;
+  align-items: center;
   gap: 8px;
+  margin: 4px 0;
 }
 
 .button {

--- a/src/components/DataDropdown.jsx
+++ b/src/components/DataDropdown.jsx
@@ -1,0 +1,56 @@
+import { useRef } from 'react';
+import useClickOutside from './useClickOutside';
+import styles from '../InventoryTab.module.css';
+
+export default function DataDropdown({
+  onClose,
+  handleImportClick,
+  handleExportClick,
+  handleDriveImport,
+  handleDriveExport,
+  handleDropboxImport,
+  handleDropboxExport,
+  handleOneDriveImport,
+  handleOneDriveExport,
+  handleICloudImport,
+  handleICloudExport
+}) {
+  const ref = useRef();
+  useClickOutside(ref, onClose);
+
+  const handleAction = action => {
+    action();
+    onClose();
+  };
+
+  return (
+    <div className={`action-dropdown ${styles.dataDropdown}`} ref={ref}>
+      <div className={styles.dataRow}>
+        <span>CSV:</span>
+        <button onClick={() => handleAction(handleImportClick)}>匯入</button>
+        <button onClick={() => handleAction(handleExportClick)}>匯出</button>
+      </div>
+      <div className={styles.dataRow}>
+        <span>Google Drive:</span>
+        <button onClick={() => handleAction(handleDriveImport)}>匯入</button>
+        <button onClick={() => handleAction(handleDriveExport)}>匯出</button>
+      </div>
+      <div className={styles.dataRow}>
+        <span>Dropbox:</span>
+        <button onClick={() => handleAction(handleDropboxImport)}>匯入</button>
+        <button onClick={() => handleAction(handleDropboxExport)}>匯出</button>
+      </div>
+      <div className={styles.dataRow}>
+        <span>OneDrive:</span>
+        <button onClick={() => handleAction(handleOneDriveImport)}>匯入</button>
+        <button onClick={() => handleAction(handleOneDriveExport)}>匯出</button>
+      </div>
+      <div className={styles.dataRow}>
+        <span>iCloudDrive:</span>
+        <button onClick={() => handleAction(handleICloudImport)}>匯入</button>
+        <button onClick={() => handleAction(handleICloudExport)}>匯出</button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Replace data access buttons with dropdown menu mirroring other display style
- Organize import/export actions for CSV, Google Drive, Dropbox, OneDrive and iCloud
- Add specific dropdown styling rules

## Testing
- `pnpm test`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c29ae7d2348329a295aabfaae45bc9