### PR TITLE
refactor: clean calendar totals and tidy data menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -369,12 +369,6 @@ button:active {
   color: #0d6efd;
   cursor: pointer;
 }
-.calendar-total {
-  margin-top: 8px;
-  text-align: right;
-  font-weight: bold;
-}
-
 /* .inventory-tables {
   display: flex;
   gap: 24px;

--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -25,17 +25,27 @@
 
 
 .dataDropdown button {
-  display: inline-block;
-  width: auto;
-  margin: 0 0 0 4px;
+  width: 60px;
+  margin: 0;
   text-align: center;
 }
 
 .dataRow {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
   margin: 4px 0;
+}
+
+.dataLabel {
+  flex: 1;
+  white-space: nowrap;
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 4px;
 }
 
 .button {

--- a/src/components/DataDropdown.jsx
+++ b/src/components/DataDropdown.jsx
@@ -26,29 +26,39 @@ export default function DataDropdown({
   return (
     <div className={`action-dropdown ${styles.dataDropdown}`} ref={ref}>
       <div className={styles.dataRow}>
-        <span>CSV:</span>
-        <button onClick={() => handleAction(handleImportClick)}>匯入</button>
-        <button onClick={() => handleAction(handleExportClick)}>匯出</button>
+        <span className={styles.dataLabel}>CSV</span>
+        <div className={styles.buttonGroup}>
+          <button onClick={() => handleAction(handleImportClick)}>匯入</button>
+          <button onClick={() => handleAction(handleExportClick)}>匯出</button>
+        </div>
       </div>
       <div className={styles.dataRow}>
-        <span>Google Drive:</span>
-        <button onClick={() => handleAction(handleDriveImport)}>匯入</button>
-        <button onClick={() => handleAction(handleDriveExport)}>匯出</button>
+        <span className={styles.dataLabel}>Google Drive</span>
+        <div className={styles.buttonGroup}>
+          <button onClick={() => handleAction(handleDriveImport)}>匯入</button>
+          <button onClick={() => handleAction(handleDriveExport)}>匯出</button>
+        </div>
       </div>
       <div className={styles.dataRow}>
-        <span>Dropbox:</span>
-        <button onClick={() => handleAction(handleDropboxImport)}>匯入</button>
-        <button onClick={() => handleAction(handleDropboxExport)}>匯出</button>
+        <span className={styles.dataLabel}>Dropbox</span>
+        <div className={styles.buttonGroup}>
+          <button onClick={() => handleAction(handleDropboxImport)}>匯入</button>
+          <button onClick={() => handleAction(handleDropboxExport)}>匯出</button>
+        </div>
       </div>
       <div className={styles.dataRow}>
-        <span>OneDrive:</span>
-        <button onClick={() => handleAction(handleOneDriveImport)}>匯入</button>
-        <button onClick={() => handleAction(handleOneDriveExport)}>匯出</button>
+        <span className={styles.dataLabel}>OneDrive</span>
+        <div className={styles.buttonGroup}>
+          <button onClick={() => handleAction(handleOneDriveImport)}>匯入</button>
+          <button onClick={() => handleAction(handleOneDriveExport)}>匯出</button>
+        </div>
       </div>
       <div className={styles.dataRow}>
-        <span>iCloudDrive:</span>
-        <button onClick={() => handleAction(handleICloudImport)}>匯入</button>
-        <button onClick={() => handleAction(handleICloudExport)}>匯出</button>
+        <span className={styles.dataLabel}>iCloudDrive</span>
+        <div className={styles.buttonGroup}>
+          <button onClick={() => handleAction(handleICloudImport)}>匯入</button>
+          <button onClick={() => handleAction(handleICloudExport)}>匯出</button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/DividendCalendar.jsx
+++ b/src/components/DividendCalendar.jsx
@@ -36,9 +36,6 @@ export default function DividendCalendar({ year, events }) {
   const prevMonth = () => setMonth(m => (m === 0 ? 11 : m - 1));
   const nextMonth = () => setMonth(m => (m === 11 ? 0 : m + 1));
 
-  const monthEvents = events.filter(e => new Date(e.date).getFullYear() === year && new Date(e.date).getMonth() === month);
-  const exTotal = monthEvents.filter(e => e.type === 'ex').reduce((sum, e) => sum + Number(e.amount || 0), 0);
-  const payTotal = monthEvents.filter(e => e.type === 'pay').reduce((sum, e) => sum + Number(e.amount || 0), 0);
 
   return (
     <div className="calendar">
@@ -51,7 +48,6 @@ export default function DividendCalendar({ year, events }) {
         <span><span className="legend-box legend-ex"></span>除息日</span>
         <span style={{ marginLeft: 8 }}><span className="legend-box legend-pay"></span>發放日</span>
       </div>
-      <div className="calendar-total">當月除息合計: {exTotal.toFixed(1)} / 發放合計: {payTotal.toFixed(1)}</div>
       <div className="table-responsive">
       <table className="calendar-grid">
         <thead>


### PR DESCRIPTION
## Summary
- remove monthly ex-dividend and payout totals from dividend calendar
- refactor data storage dropdown for clearer layout

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2aad32aa8832990cd1ec6732732b2