### PR TITLE
style: add silver black-gold buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -223,6 +223,20 @@ td {
   background: var(--color-row-even);
 }
 
+.silver-button-container button {
+  background: linear-gradient(#e0e0e0, #bcbcbc);
+  color: #000;
+  border: 1px solid #d4af37;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 4px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+}
+
+.silver-button-container button:hover {
+  background: linear-gradient(#bcbcbc, #e0e0e0);
+}
+
 .slogan {
   font-size: 1.4rem;
   margin-top: 0;

--- a/src/components/DataDropdown.jsx
+++ b/src/components/DataDropdown.jsx
@@ -24,7 +24,7 @@ export default function DataDropdown({
   };
 
   return (
-    <div className={`action-dropdown ${styles.dataDropdown}`} ref={ref}>
+    <div className={`action-dropdown silver-button-container ${styles.dataDropdown}`} ref={ref}>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>CSV</span>
         <div className={styles.buttonGroup}>

--- a/src/components/DisplayDropdown.jsx
+++ b/src/components/DisplayDropdown.jsx
@@ -17,7 +17,7 @@ export default function DisplayDropdown({
   };
 
   return (
-      <div className="action-dropdown" ref={ref}>
+      <div className="action-dropdown silver-button-container" ref={ref}>
         <button onClick={() => handleClick(toggleDividendYield)}>
           {showDividendYield ? '顯示配息' : '顯示殖利率'}
         </button>


### PR DESCRIPTION
## Summary
- style dropdown buttons with silver, black, and gold aesthetics
- apply styling to dividend/info toggle and import/export options

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2b9ee2f048329bf5a9b8d79892b52