### PR TITLE
feat: add cookie consent banner

### DIFF
--- a/src/CookieConsent.test.jsx
+++ b/src/CookieConsent.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Cookies from 'js-cookie';
+import CookieConsent from './components/CookieConsent.jsx';
+
+describe('CookieConsent', () => {
+  beforeEach(() => {
+    Cookies.remove('cookie_consent');
+  });
+
+  test('renders banner and hides after acceptance', () => {
+    render(<CookieConsent />);
+    expect(
+      screen.getByText(/本網站使用 Cookie 以提升使用者體驗/)
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '知道了！' }));
+    expect(
+      screen.queryByText(/本網站使用 Cookie 以提升使用者體驗/)
+    ).not.toBeInTheDocument();
+    expect(Cookies.get('cookie_consent')).toBe('true');
+  });
+});

--- a/src/components/CookieConsent.css
+++ b/src/components/CookieConsent.css
@@ -1,0 +1,29 @@
+.cookie-consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: var(--color-card-bg);
+  color: var(--color-text);
+  border-top: 1px solid var(--color-border);
+  padding: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  z-index: 1000;
+}
+
+.cookie-consent button {
+  background-color: var(--accent-gold);
+  border: none;
+  color: var(--color-bg);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.cookie-consent button:hover {
+  background-color: var(--accent-gold-hover);
+}

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+import Cookies from 'js-cookie';
+import './CookieConsent.css';
+
+const COOKIE_NAME = 'cookie_consent';
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = Cookies.get(COOKIE_NAME);
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    Cookies.set(COOKIE_NAME, 'true', { expires: 365 });
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="cookie-consent">
+      <span>
+        本網站使用 Cookie 以提升使用者體驗。繼續瀏覽表示您同意我們使用 Cookie。
+      </span>
+      <button onClick={accept}>知道了！</button>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.jsx'
 import StockDetail from './StockDetail.jsx'
+import CookieConsent from './components/CookieConsent.jsx'
 
 const path = window.location.pathname;
 const match = path.match(/^\/stock\/(\w+)/);
@@ -13,6 +14,7 @@ const queryClient = new QueryClient();
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
+      <CookieConsent />
       {stockId ? <StockDetail stockId={stockId} /> : <App />}
     </QueryClientProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- add cookie consent banner component with basic styling and cookie storage
- render cookie consent across the app
- cover banner behavior with tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c0e51990832980da376e2cf363c5