### PR TITLE
feat: show monthly dividend totals

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -304,10 +304,18 @@ button:active {
 }
 .calendar-header {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.calendar-nav {
+  display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 8px;
+}
+.calendar-summary {
+  text-align: right;
+  font-size: 14px;
 }
 .calendar-legend {
   text-align: center;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,7 @@ function App() {
   const [showCalendar, setShowCalendar] = useState(true);
 
   // Filter which event types to show on calendar
-  const [calendarFilter, setCalendarFilter] = useState('ex');
+  const [calendarFilter, setCalendarFilter] = useState('both');
 
   // Toggle between showing dividend or dividend yield
   const [showDividendYield, setShowDividendYield] = useState(false);

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -20,7 +20,7 @@ function getTransactionHistory() {
 export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const [history, setHistory] = useState([]);
     const [showCalendar, setShowCalendar] = useState(true);
-    const [calendarFilter, setCalendarFilter] = useState('ex');
+    const [calendarFilter, setCalendarFilter] = useState('both');
     const timeZone = 'Asia/Taipei';
     const currentMonth = Number(new Date().toLocaleString('en-US', { timeZone, month: 'numeric' })) - 1;
     const [sortConfig, setSortConfig] = useState({ column: 'stock_id', direction: 'asc' });

--- a/src/UserDividendsTab.test.jsx
+++ b/src/UserDividendsTab.test.jsx
@@ -4,7 +4,6 @@ import UserDividendsTab from './UserDividendsTab';
 import { readTransactionHistory } from './transactionStorage';
 
 jest.mock('./transactionStorage');
-jest.mock('./components/DividendCalendar', () => () => null);
 jest.mock('./config', () => ({ API_HOST: '' }));
 
 test('displays stock id and dynamic name from dividend data', async () => {
@@ -18,4 +17,30 @@ test('displays stock id and dynamic name from dividend data', async () => {
 
   render(<UserDividendsTab allDividendData={allDividendData} selectedYear={2024} />);
   expect(await screen.findByText('0050 Test ETF')).toBeInTheDocument();
+});
+
+test('calendar defaults to showing both ex and payment events', async () => {
+  const nowStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' });
+  const [year, month] = nowStr.split('-');
+  readTransactionHistory.mockReturnValue([
+    { stock_id: 'AAA', date: `${year}-01-01`, quantity: 1000, type: 'buy' }
+  ]);
+  const data = [
+    {
+      stock_id: 'AAA',
+      stock_name: 'AAA',
+      dividend: '1',
+      dividend_date: `${year}-${month}-05`,
+      payment_date: `${year}-${month}-15`,
+      dividend_yield: '1',
+      last_close_price: '10'
+    }
+  ];
+
+  render(<UserDividendsTab allDividendData={data} selectedYear={Number(year)} />);
+
+  expect(await screen.findByText('除息: 1,000')).toBeInTheDocument();
+  expect(await screen.findByText('發放: 1,000')).toBeInTheDocument();
+  const bothBtn = screen.getByRole('button', { name: '除息/發放日' });
+  expect(bothBtn).toHaveStyle({ fontWeight: 'bold' });
 });

--- a/src/components/DividendCalendar.jsx
+++ b/src/components/DividendCalendar.jsx
@@ -10,6 +10,15 @@ export default function DividendCalendar({ year, events }) {
   const [expandedDates, setExpandedDates] = useState({});
   const todayStr = nowStr;
 
+  const monthStr = String(month + 1).padStart(2, '0');
+  const monthEvents = events.filter(e => e.date.startsWith(`${year}-${monthStr}`));
+  const exTotal = monthEvents
+    .filter(e => e.type === 'ex')
+    .reduce((sum, e) => sum + (Number(e.amount) || 0), 0);
+  const payTotal = monthEvents
+    .filter(e => e.type === 'pay')
+    .reduce((sum, e) => sum + (Number(e.amount) || 0), 0);
+
   const firstDay = new Date(year, month, 1);
   const daysInMonth = new Date(year, month + 1, 0).getDate();
   const startDay = firstDay.getDay();
@@ -40,9 +49,17 @@ export default function DividendCalendar({ year, events }) {
   return (
     <div className="calendar">
       <div className="calendar-header">
-        <button onClick={prevMonth} style={{ all: 'unset',  }}>◀</button>
-        <span>{year} {MONTH_NAMES[month]}</span>
-        <button onClick={nextMonth} style={{ all: 'unset',  }}>▶</button>
+        <div className="calendar-nav">
+          <button onClick={prevMonth} style={{ all: 'unset' }}>◀</button>
+          <span>{year} {MONTH_NAMES[month]}</span>
+          <button onClick={nextMonth} style={{ all: 'unset' }}>▶</button>
+        </div>
+        {(exTotal > 0 || payTotal > 0) && (
+          <div className="calendar-summary">
+            <span>除息: {Math.round(exTotal).toLocaleString()}</span>
+            <span style={{ marginLeft: 8 }}>發放: {Math.round(payTotal).toLocaleString()}</span>
+          </div>
+        )}
       </div>
       <div className="calendar-legend">
         <span><span className="legend-box legend-ex"></span>除息日</span>

--- a/src/components/DividendCalendar.test.jsx
+++ b/src/components/DividendCalendar.test.jsx
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import DividendCalendar from './DividendCalendar';
+
+test('displays monthly ex and pay totals', () => {
+  const nowStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' });
+  const [year, month] = nowStr.split('-');
+  const events = [
+    { date: `${year}-${month}-05`, type: 'ex', amount: 100 },
+    { date: `${year}-${month}-15`, type: 'pay', amount: 200 }
+  ];
+  render(<DividendCalendar year={Number(year)} events={events} />);
+  expect(screen.getByText('除息: 100')).toBeInTheDocument();
+  expect(screen.getByText('發放: 200')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- display per-month ex-dividend and payment totals above calendar
- default calendar filters to show ex- and payment days with combined toggle active
- add tests for calendar totals and default filter state

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2de31c28c8329a9cae4bd7c13c7b7