### PR TITLE
feat: make dividend calendar totals optional

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -613,7 +613,7 @@ function App() {
                       除息/發放日
                     </button>
                   </div>
-                  <DividendCalendar year={selectedYear} events={filteredCalendarEvents} />
+                  <DividendCalendar year={selectedYear} events={filteredCalendarEvents} showTotals={false} />
                 </>
               )}
 

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -227,7 +227,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                             除息/發放日
                         </button>
                     </div>
-                    <DividendCalendar year={selectedYear} events={filteredCalendarEvents} />
+                    <DividendCalendar year={selectedYear} events={filteredCalendarEvents} showTotals />
                 </>
             )}
 

--- a/src/components/DividendCalendar.jsx
+++ b/src/components/DividendCalendar.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 const MONTH_NAMES = ['1月','2月','3月','4月','5月','6月','7月','8月','9月','10月','11月','12月'];
 const DAY_NAMES = ['日','一','二','三','四','五','六'];
 
-export default function DividendCalendar({ year, events }) {
+export default function DividendCalendar({ year, events, showTotals = true }) {
   const timeZone = 'Asia/Taipei';
   const nowStr = new Date().toLocaleDateString('en-CA', { timeZone });
   const [month, setMonth] = useState(Number(nowStr.slice(5, 7)) - 1);
@@ -54,7 +54,7 @@ export default function DividendCalendar({ year, events }) {
           <span>{year} {MONTH_NAMES[month]}</span>
           <button onClick={nextMonth} style={{ all: 'unset' }}>▶</button>
         </div>
-        {(exTotal > 0 || payTotal > 0) && (
+        {showTotals && (exTotal > 0 || payTotal > 0) && (
           <div className="calendar-summary">
             <span>除息: {Math.round(exTotal).toLocaleString()}</span>
             <span style={{ marginLeft: 8 }}>發放: {Math.round(payTotal).toLocaleString()}</span>

--- a/src/components/DividendCalendar.test.jsx
+++ b/src/components/DividendCalendar.test.jsx
@@ -13,3 +13,15 @@ test('displays monthly ex and pay totals', () => {
   expect(screen.getByText('除息: 100')).toBeInTheDocument();
   expect(screen.getByText('發放: 200')).toBeInTheDocument();
 });
+
+test('hides monthly totals when showTotals is false', () => {
+  const nowStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' });
+  const [year, month] = nowStr.split('-');
+  const events = [
+    { date: `${year}-${month}-05`, type: 'ex', amount: 100 },
+    { date: `${year}-${month}-15`, type: 'pay', amount: 200 }
+  ];
+  render(<DividendCalendar year={Number(year)} events={events} showTotals={false} />);
+  expect(screen.queryByText('除息: 100')).not.toBeInTheDocument();
+  expect(screen.queryByText('發放: 200')).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add `showTotals` prop to `DividendCalendar` so totals can be toggled
- hide totals on monthly dividend table calendar, keep them on dividend overview
- add test coverage for show/hide behaviour

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2e6c63c348329af1235d18906b1c5