### PR TITLE
Default calendar filter to show combined dividend dates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,7 @@ function App() {
   const [showCalendar, setShowCalendar] = useState(true);
 
   // Filter which event types to show on calendar
+  // Default to displaying both ex-dividend and payment dates
   const [calendarFilter, setCalendarFilter] = useState('both');
 
   // Toggle between showing dividend or dividend yield

--- a/src/AppCalendarFilter.test.jsx
+++ b/src/AppCalendarFilter.test.jsx
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import { render, screen, fireEvent } from '@testing-library/react';
+// Mock asset imports used by App
+jest.mock('./assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('./assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+
+jest.mock('./api', () => ({
+  fetchWithCache: jest.fn(() => Promise.resolve({ data: [], cacheStatus: 'fresh', timestamp: '' })),
+  clearCache: jest.fn(),
+}));
+
+jest.mock('./config', () => ({ API_HOST: '' }));
+
+import App from './App';
+
+beforeAll(() => {
+  global.fetch = jest.fn(() => Promise.resolve({}));
+});
+
+test('calendar defaults to showing both ex and payment events', async () => {
+  render(<App />);
+  const dividendTab = screen.getByRole('button', { name: 'ETF 配息查詢' });
+  fireEvent.click(dividendTab);
+  const bothBtn = await screen.findByRole('button', { name: '除息/發放日' });
+  expect(bothBtn).toHaveStyle({ fontWeight: 'bold' });
+});

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -20,6 +20,7 @@ function getTransactionHistory() {
 export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const [history, setHistory] = useState([]);
     const [showCalendar, setShowCalendar] = useState(true);
+    // Default to showing both ex-dividend and payment events
     const [calendarFilter, setCalendarFilter] = useState('both');
     const timeZone = 'Asia/Taipei';
     const currentMonth = Number(new Date().toLocaleString('en-US', { timeZone, month: 'numeric' })) - 1;

--- a/src/UserDividendsTab.test.jsx
+++ b/src/UserDividendsTab.test.jsx
@@ -39,8 +39,8 @@ test('calendar defaults to showing both ex and payment events', async () => {
 
   render(<UserDividendsTab allDividendData={data} selectedYear={Number(year)} />);
 
-  expect(await screen.findByText('除息: 1,000')).toBeInTheDocument();
-  expect(await screen.findByText('發放: 1,000')).toBeInTheDocument();
+  expect(await screen.findByText('除息金額: 1,000')).toBeInTheDocument();
+  expect(await screen.findByText('發放金額: 1,000')).toBeInTheDocument();
   const bothBtn = screen.getByRole('button', { name: '除息/發放日' });
   expect(bothBtn).toHaveStyle({ fontWeight: 'bold' });
 });

--- a/src/components/DividendCalendar.test.jsx
+++ b/src/components/DividendCalendar.test.jsx
@@ -10,8 +10,8 @@ test('displays monthly ex and pay totals', () => {
     { date: `${year}-${month}-15`, type: 'pay', amount: 200 }
   ];
   render(<DividendCalendar year={Number(year)} events={events} />);
-  expect(screen.getByText('除息: 100')).toBeInTheDocument();
-  expect(screen.getByText('發放: 200')).toBeInTheDocument();
+  expect(screen.getByText('除息金額: 100')).toBeInTheDocument();
+  expect(screen.getByText('發放金額: 200')).toBeInTheDocument();
 });
 
 test('hides monthly totals when showTotals is false', () => {
@@ -22,6 +22,6 @@ test('hides monthly totals when showTotals is false', () => {
     { date: `${year}-${month}-15`, type: 'pay', amount: 200 }
   ];
   render(<DividendCalendar year={Number(year)} events={events} showTotals={false} />);
-  expect(screen.queryByText('除息: 100')).not.toBeInTheDocument();
-  expect(screen.queryByText('發放: 200')).not.toBeInTheDocument();
+  expect(screen.queryByText('除息金額: 100')).not.toBeInTheDocument();
+  expect(screen.queryByText('發放金額: 200')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- clarify calendar filter defaulting to both ex-dividend and payment dates
- add tests ensuring combined date view is selected by default

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c300e601b483298a7c3e01a2071898