### PR TITLE
Underline About page h3 headings

### DIFF
--- a/src/AppCalendarFilter.test.jsx
+++ b/src/AppCalendarFilter.test.jsx
@@ -14,7 +14,7 @@ jest.mock('./config', () => ({ API_HOST: '' }));
 import App from './App';
 
 beforeAll(() => {
-  global.fetch = jest.fn(() => Promise.resolve({}));
+  globalThis.fetch = jest.fn(() => Promise.resolve({}));
 });
 
 test('calendar defaults to showing both ex and payment events', async () => {

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,10 @@ body {
   font-size: 0.9rem;
 }
 
-.about-tab h4 {
+.about-tab h3 {
   text-decoration: underline;
+}
+
+.about-tab h4 {
+  text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- Add underline styling to About page `<h3>` headings
- Remove underline styling from About page `<h4>` elements
- Replace deprecated `global` reference with `globalThis` in tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d6f7b7bc8329be10a6eb79fa9974