### PR TITLE
feat: add language toggle with theme switch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { LanguageContext, translations } from './i18n';
 import InventoryTab from './InventoryTab';
 import UserDividendsTab from './UserDividendsTab';
 import AboutTab from './AboutTab';
@@ -88,6 +89,13 @@ function App() {
   }, [theme]);
 
   const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark');
+
+  // Language
+  const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'zh');
+  useEffect(() => {
+    localStorage.setItem('lang', lang);
+  }, [lang]);
+  const t = useMemo(() => (key) => translations[lang][key] || key, [lang]);
 
   const [editingGroupIndex, setEditingGroupIndex] = useState(null);
   const [groupNameInput, setGroupNameInput] = useState('');
@@ -493,6 +501,7 @@ function App() {
 
 
   return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
     <div className="container">
     <header className="mb-1 text-center">
       <img
@@ -516,7 +525,7 @@ function App() {
             className={`nav-link${tab === 'home' ? ' active' : ''}`}
             onClick={() => setTab('home')}
           >
-            首頁
+            {t('home')}
           </button>
         </li>
         <li className="nav-item">
@@ -524,7 +533,7 @@ function App() {
             className={`nav-link${tab === 'mydividend' ? ' active' : ''}`}
             onClick={() => setTab('mydividend')}
           >
-            我的配息
+            {t('mydividend')}
           </button>
         </li>
         <li className="nav-item">
@@ -532,7 +541,7 @@ function App() {
             className={`nav-link${tab === 'dividend' ? ' active' : ''}`}
             onClick={() => setTab('dividend')}
           >
-            ETF 配息查詢
+            {t('dividend')}
           </button>
         </li>
         <li className="nav-item">
@@ -540,7 +549,7 @@ function App() {
             className={`nav-link${tab === 'inventory' ? ' active' : ''}`}
             onClick={() => setTab('inventory')}
           >
-            庫存管理
+            {t('inventory')}
           </button>
         </li>
         <li className="nav-item">
@@ -548,7 +557,7 @@ function App() {
             className={`nav-link${tab === 'about' ? ' active' : ''}`}
             onClick={() => setTab('about')}
           >
-            關於本站
+            {t('about')}
           </button>
         </li>
       </ul>
@@ -750,6 +759,7 @@ function App() {
       )}
       <Footer theme={theme} toggleTheme={toggleTheme} />
     </div>
+    </LanguageContext.Provider>
   );
 }
 

--- a/src/Footer.test.jsx
+++ b/src/Footer.test.jsx
@@ -1,11 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import Footer from './components/Footer.jsx';
+import { LanguageContext, translations } from './i18n';
 
 test('renders contact info and dynamic copyright', () => {
   const year = new Date().getFullYear();
-  render(<Footer theme="dark" toggleTheme={() => {}} />);
-  expect(screen.getByRole('link', { name: '亮色主題' })).toBeInTheDocument();
-  expect(screen.getByRole('link', { name: '贊助' })).toBeInTheDocument();
+  const lang = 'zh';
+  const t = (key) => translations[lang][key];
+  render(
+    <LanguageContext.Provider value={{ lang, setLang: () => {}, t }}>
+      <Footer theme="dark" toggleTheme={() => {}} />
+    </LanguageContext.Provider>
+  );
+  expect(screen.getByRole('link', { name: t('light_theme') })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: '英' })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: t('donate') })).toBeInTheDocument();
   expect(
     screen.getByText(`© ${year} ETF Life. All rights reserved.`)
   ).toBeInTheDocument();

--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { API_HOST } from './config';
 import { fetchWithCache } from './api';
+import { useLanguage } from './i18n';
 
 export default function HomeTab() {
   const [stats, setStats] = useState({ milestones: [], latest: [], tip: '' });
+  const { t } = useLanguage();
 
   useEffect(() => {
     let cancelled = false;
@@ -26,7 +28,7 @@ export default function HomeTab() {
   return (
     <div className="container" style={{ maxWidth: 800 }}>
       <section className="mt-4">
-        <h5>本站數據概況</h5>
+        <h5>{t('site_stats')}</h5>
         <div style={{ display: 'flex', justifyContent: 'space-between', textAlign: 'center', marginTop: 16 }}>
           {stats.milestones.map((m, idx) => (
             <div key={idx} style={{ flex: 1 }}>
@@ -37,7 +39,7 @@ export default function HomeTab() {
         </div>
       </section>
       <section className="mt-4">
-        <h5>最新收錄</h5>
+        <h5>{t('latest')}</h5>
         <ul>
           {stats.latest.map((item, idx) => (
             <li key={idx}>{item}</li>
@@ -48,7 +50,7 @@ export default function HomeTab() {
         className="mt-4"
         style={{ background: 'var(--color-row-even)', padding: 16, borderRadius: 4 }}
       >
-        <h5>ETF 小知識</h5>
+        <h5>{t('etf_tips')}</h5>
         <p style={{ margin: 0 }}>{stats.tip}</p>
       </section>
     </div>

--- a/src/HomeTab.test.jsx
+++ b/src/HomeTab.test.jsx
@@ -2,6 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import HomeTab from './HomeTab';
 import { fetchWithCache } from './api';
+import { LanguageContext, translations } from './i18n';
 
 jest.mock('./api');
 jest.mock('./config', () => ({
@@ -29,23 +30,32 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
+const renderWithLang = (lang = 'zh') => {
+  const t = (key) => translations[lang][key];
+  return render(
+    <LanguageContext.Provider value={{ lang, setLang: () => {}, t }}>
+      <HomeTab />
+    </LanguageContext.Provider>
+  );
+};
+
 test('renders data milestones section', async () => {
-  render(<HomeTab />);
-  await screen.findByText('本站數據概況');
+  renderWithLang();
+  await screen.findByText(translations.zh.site_stats);
   expect(await screen.findByText('301')).toBeInTheDocument();
 });
 
 test('renders latest updates section', async () => {
-  render(<HomeTab />);
-  await screen.findByText('最新收錄');
+  renderWithLang();
+  await screen.findByText(translations.zh.latest);
   expect(
     await screen.findByText('✅ 已更新 2025 年 9 月最新配息數據')
   ).toBeInTheDocument();
 });
 
 test('renders knowledge section', async () => {
-  render(<HomeTab />);
-  await screen.findByText('ETF 小知識');
+  renderWithLang();
+  await screen.findByText(translations.zh.etf_tips);
   expect(
     await screen.findByText(
       '高股息 ETF 不代表報酬率高，還需要考慮殖利率與價格變化。'

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -14,10 +14,21 @@
 
 .theme-toggle {
   margin-bottom: 5px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
 .theme-toggle-link {
   cursor: pointer;
+}
+
+.language-toggle {
+  margin-top: 4px;
+}
+
+.language-toggle button {
+  margin-left: 4px;
 }
 
 .donation-section {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,9 @@
 import './Footer.css';
+import { useLanguage } from '../i18n';
 
 export default function Footer({ theme, toggleTheme }) {
   const year = new Date().getFullYear();
+  const { lang, setLang, t } = useLanguage();
   return (
     <footer className="footer">
       <div className="footer-content">
@@ -14,24 +16,28 @@ export default function Footer({ theme, toggleTheme }) {
             }}
             className="theme-toggle-link"
           >
-            {theme === 'dark' ? '亮色主題' : '暗色主題'}
+            {theme === 'dark' ? t('light_theme') : t('dark_theme')}
           </a>
+          <div className="language-toggle">
+            <button onClick={() => setLang('zh')} disabled={lang === 'zh'}>中</button>
+            <button onClick={() => setLang('en')} disabled={lang === 'en'}>英</button>
+          </div>
         </div>
         <div className="contact-section">
           <p>
-            電子信箱：
+            {t('email_label')}
             <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a>
           </p>
         </div>
         <div className="donation-section">
-          喜歡這個專案嗎？請作者喝杯咖啡 ☕ 
+          {t('donate_prompt')}
           <a
             href="https://www.buymeacoffee.com/ginatbean"
             target="_blank"
             rel="noreferrer"
             className="donate-link"
           >
-            贊助
+            {t('donate')}
           </a>
         </div>
       </div>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,42 @@
+import { createContext, useContext } from 'react';
+
+export const translations = {
+  zh: {
+    light_theme: '亮色主題',
+    dark_theme: '暗色主題',
+    email_label: '電子信箱：',
+    donate_prompt: '喜歡這個專案嗎？請作者喝杯咖啡 ☕',
+    donate: '贊助',
+    site_stats: '本站數據概況',
+    latest: '最新收錄',
+    etf_tips: 'ETF 小知識',
+    home: '首頁',
+    inventory: '庫存管理',
+    mydividend: '我的配息',
+    dividend: 'ETF 配息查詢',
+    about: '關於本站'
+  },
+  en: {
+    light_theme: 'Light Theme',
+    dark_theme: 'Dark Theme',
+    email_label: 'Email:',
+    donate_prompt: 'Enjoy this project? Buy the author a coffee ☕',
+    donate: 'Donate',
+    site_stats: 'Site Stats',
+    latest: 'Latest Listings',
+    etf_tips: 'ETF Tips',
+    home: 'Home',
+    inventory: 'Inventory',
+    mydividend: 'My Dividends',
+    dividend: 'Dividend Search',
+    about: 'About'
+  }
+};
+
+export const LanguageContext = createContext({
+  lang: 'zh',
+  setLang: () => {},
+  t: (key) => translations.zh[key] || key
+});
+
+export const useLanguage = () => useContext(LanguageContext);


### PR DESCRIPTION
## Summary
- allow switching between Chinese and English with persistence
- move theme toggle to the right and add language buttons
- translate navigation and home tab headings

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3d7f5efb083298e253e1fbfec0732