### PR TITLE
feat: add selectable calendar filters and toggles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -618,3 +618,12 @@ button:active {
 .more-item {
   position: relative;
 }
+
+/* Selected/unselected button styles */
+.btn-selected {
+  font-weight: bold;
+}
+
+.btn-unselected {
+  opacity: 0.6;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,7 +88,6 @@ function App() {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
-  const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark');
 
   // Language
   const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'zh');
@@ -606,19 +605,21 @@ function App() {
                   <div style={{ margin: '10px 0' }}>
                     <button
                       onClick={() => setCalendarFilter('ex')}
-                      style={{ fontWeight: calendarFilter === 'ex' ? 'bold' : 'normal' }}
+                      className={calendarFilter === 'ex' ? 'btn-selected' : 'btn-unselected'}
                     >
                       除息日
                     </button>
                     <button
                       onClick={() => setCalendarFilter('pay')}
-                      style={{ fontWeight: calendarFilter === 'pay' ? 'bold' : 'normal', marginLeft: 6 }}
+                      className={calendarFilter === 'pay' ? 'btn-selected' : 'btn-unselected'}
+                      style={{ marginLeft: 6 }}
                     >
                       發放日
                     </button>
                     <button
                       onClick={() => setCalendarFilter('both')}
-                      style={{ fontWeight: calendarFilter === 'both' ? 'bold' : 'normal', marginLeft: 6 }}
+                      className={calendarFilter === 'both' ? 'btn-selected' : 'btn-unselected'}
+                      style={{ marginLeft: 6 }}
                     >
                       除息/發放日
                     </button>
@@ -757,7 +758,7 @@ function App() {
           </div>
         </div>
       )}
-      <Footer theme={theme} toggleTheme={toggleTheme} />
+      <Footer theme={theme} setTheme={setTheme} />
     </div>
     </LanguageContext.Provider>
   );

--- a/src/AppCalendarFilter.test.jsx
+++ b/src/AppCalendarFilter.test.jsx
@@ -22,5 +22,5 @@ test('calendar defaults to showing both ex and payment events', async () => {
   const dividendTab = screen.getByRole('button', { name: 'ETF 配息查詢' });
   fireEvent.click(dividendTab);
   const bothBtn = await screen.findByRole('button', { name: '除息/發放日' });
-  expect(bothBtn).toHaveStyle({ fontWeight: 'bold' });
+  expect(bothBtn).toHaveClass('btn-selected');
 });

--- a/src/Footer.test.jsx
+++ b/src/Footer.test.jsx
@@ -8,11 +8,13 @@ test('renders contact info and dynamic copyright', () => {
   const t = (key) => translations[lang][key];
   render(
     <LanguageContext.Provider value={{ lang, setLang: () => {}, t }}>
-      <Footer theme="dark" toggleTheme={() => {}} />
+      <Footer theme="dark" setTheme={() => {}} />
     </LanguageContext.Provider>
   );
-  expect(screen.getByRole('link', { name: t('light_theme') })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: '英' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: t('light') })).toBeInTheDocument();
+  const darkBtn = screen.getByRole('button', { name: t('dark') });
+  expect(darkBtn).toHaveClass('btn-selected');
+  expect(screen.getByRole('button', { name: t('english') })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: t('donate') })).toBeInTheDocument();
   expect(
     screen.getByText(`© ${year} ETF Life. All rights reserved.`)

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -10,7 +10,6 @@ export default function StockDetail({ stockId }) {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
-  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
   const { data: stockList = [], isLoading: stockLoading, dataUpdatedAt: stockUpdatedAt } = useQuery({
     queryKey: ['stockList'],
     queryFn: async () => {
@@ -158,7 +157,7 @@ export default function StockDetail({ stockId }) {
         </div>
       )}
     </div>
-    <Footer theme={theme} toggleTheme={toggleTheme} />
+    <Footer theme={theme} setTheme={setTheme} />
     </>
   );
 }

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -211,19 +211,21 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     <div style={{ margin: '10px 0' }}>
                         <button
                             onClick={() => setCalendarFilter('ex')}
-                            style={{ fontWeight: calendarFilter === 'ex' ? 'bold' : 'normal' }}
+                            className={calendarFilter === 'ex' ? 'btn-selected' : 'btn-unselected'}
                         >
                             除息日
                         </button>
                         <button
                             onClick={() => setCalendarFilter('pay')}
-                            style={{ fontWeight: calendarFilter === 'pay' ? 'bold' : 'normal', marginLeft: 6 }}
+                            className={calendarFilter === 'pay' ? 'btn-selected' : 'btn-unselected'}
+                            style={{ marginLeft: 6 }}
                         >
                             發放日
                         </button>
                         <button
                             onClick={() => setCalendarFilter('both')}
-                            style={{ fontWeight: calendarFilter === 'both' ? 'bold' : 'normal', marginLeft: 6 }}
+                            className={calendarFilter === 'both' ? 'btn-selected' : 'btn-unselected'}
+                            style={{ marginLeft: 6 }}
                         >
                             除息/發放日
                         </button>

--- a/src/UserDividendsTab.test.jsx
+++ b/src/UserDividendsTab.test.jsx
@@ -42,5 +42,5 @@ test('calendar defaults to showing both ex and payment events', async () => {
   expect(await screen.findByText('除息金額: 1,000')).toBeInTheDocument();
   expect(await screen.findByText('發放金額: 1,000')).toBeInTheDocument();
   const bothBtn = screen.getByRole('button', { name: '除息/發放日' });
-  expect(bothBtn).toHaveStyle({ fontWeight: 'bold' });
+  expect(bothBtn).toHaveClass('btn-selected');
 });

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -19,15 +19,15 @@
   align-items: flex-end;
 }
 
-.theme-toggle-link {
-  cursor: pointer;
-}
-
 .language-toggle {
   margin-top: 4px;
 }
 
 .language-toggle button {
+  margin-left: 4px;
+}
+
+.theme-buttons button {
   margin-left: 4px;
 }
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,26 +1,44 @@
 import './Footer.css';
 import { useLanguage } from '../i18n';
 
-export default function Footer({ theme, toggleTheme }) {
+export default function Footer({ theme, setTheme }) {
   const year = new Date().getFullYear();
   const { lang, setLang, t } = useLanguage();
   return (
     <footer className="footer">
       <div className="footer-content">
         <div className="theme-toggle">
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              toggleTheme();
-            }}
-            className="theme-toggle-link"
-          >
-            {theme === 'dark' ? t('light_theme') : t('dark_theme')}
-          </a>
+          <div className="theme-buttons">
+            {t('theme')}：
+            <button
+              className={theme === 'light' ? 'btn-selected' : 'btn-unselected'}
+              onClick={() => setTheme('light')}
+            >
+              {t('light')}
+            </button>
+            /
+            <button
+              className={theme === 'dark' ? 'btn-selected' : 'btn-unselected'}
+              onClick={() => setTheme('dark')}
+            >
+              {t('dark')}
+            </button>
+          </div>
           <div className="language-toggle">
-            <button onClick={() => setLang('zh')} disabled={lang === 'zh'}>中</button>
-            <button onClick={() => setLang('en')} disabled={lang === 'en'}>英</button>
+            {t('language')}：
+            <button
+              className={lang === 'zh' ? 'btn-selected' : 'btn-unselected'}
+              onClick={() => setLang('zh')}
+            >
+              {t('chinese')}
+            </button>
+            /
+            <button
+              className={lang === 'en' ? 'btn-selected' : 'btn-unselected'}
+              onClick={() => setLang('en')}
+            >
+              {t('english')}
+            </button>
           </div>
         </div>
         <div className="contact-section">

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,8 +2,12 @@ import { createContext, useContext } from 'react';
 
 export const translations = {
   zh: {
-    light_theme: '亮色主題',
-    dark_theme: '暗色主題',
+    theme: '主題',
+    light: '亮',
+    dark: '暗',
+    language: '語言',
+    chinese: '中文',
+    english: 'English',
     email_label: '電子信箱：',
     donate_prompt: '喜歡這個專案嗎？請作者喝杯咖啡 ☕',
     donate: '贊助',
@@ -17,8 +21,12 @@ export const translations = {
     about: '關於本站'
   },
   en: {
-    light_theme: 'Light Theme',
-    dark_theme: 'Dark Theme',
+    theme: 'Theme',
+    light: 'Light',
+    dark: 'Dark',
+    language: 'Language',
+    chinese: 'Chinese',
+    english: 'English',
     email_label: 'Email:',
     donate_prompt: 'Enjoy this project? Buy the author a coffee ☕',
     donate: 'Donate',


### PR DESCRIPTION
## Summary
- add selected/unselected styles for dividend calendar filters
- revamp footer with language and theme toggle buttons
- support translations for theme and language labels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3e637f4bc832987e9d5ba2e14956c