### PR TITLE
feat: add English translations

### DIFF
--- a/src/AboutTab.jsx
+++ b/src/AboutTab.jsx
@@ -4,17 +4,23 @@ import FaqTab from './FaqTab';
 import DisclaimerTab from './DisclaimerTab';
 import TermsOfServiceTab from './TermsOfServiceTab';
 import PrivacyPolicyTab from './PrivacyPolicyTab';
+import { useLanguage } from './i18n';
 
 export default function AboutTab() {
+  const { lang } = useLanguage();
   return (
     <div className="about-tab">
       <div className="container" style={{ maxWidth: 800 }}>
-        <h3 className="mt-4">關於本站</h3>
+        <h3 className="mt-4">{lang === 'en' ? 'About' : '關於本站'}</h3>
         <p>
-          這裡是個幫你整理 ETF 配息的小天地，也附上簡單的持股追蹤工具。資料僅供參考，不構成投資建議唷！
+          {lang === 'en'
+            ? 'This small site helps you organize ETF dividends and offers a simple holding tracker. Data is for reference only and is not investment advice.'
+            : '這裡是個幫你整理 ETF 配息的小天地，也附上簡單的持股追蹤工具。資料僅供參考，不構成投資建議唷！'}
         </p>
         <p>
-          這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～
+          {lang === 'en'
+            ? 'This website is just a fun side project. The source code is not public for now. If you have ideas or find bugs, feel free to drop me a message.'
+            : '這個網站只是作者的趣味小作品，原始碼暫時沒有公開，如果有任何想法或發現 bug，歡迎輕鬆留言給我～'}
         </p>
       </div>
       <GuideTab />

--- a/src/DisclaimerTab.jsx
+++ b/src/DisclaimerTab.jsx
@@ -1,71 +1,79 @@
 import React from 'react';
+import { useLanguage } from './i18n';
 
 export default function DisclaimerTab() {
+  const { lang } = useLanguage();
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h3 className="mt-4">免責聲明</h3>
+      <h3 className="mt-4">{lang === 'en' ? 'Disclaimer' : '免責聲明'}</h3>
 
-      <h4>資訊性質</h4>
+      <h4>{lang === 'en' ? 'Information Only' : '資訊性質'}</h4>
       <p>
-        Dividend Life（以下稱「本站」）分享的市場資料、小工具和計算結果，
-        主要是希望大家交流和自學用的參考。這些內容真的不是投資建議，
-        也不該成為你買賣 ETF 的唯一依據喔。
+        {lang === 'en'
+          ? 'Dividend Life (the "Site") shares market data, tools and calculation results for learning and reference only. They are not investment advice and should not be your sole basis for trading ETFs.'
+          : 'Dividend Life（以下稱「本站」）分享的市場資料、小工具和計算結果，主要是希望大家交流和自學用的參考。這些內容真的不是投資建議，也不該成為你買賣 ETF 的唯一依據喔。'}
       </p>
 
-      <h4>非投顧聲明</h4>
+      <h4>{lang === 'en' ? 'No Advisory' : '非投顧聲明'}</h4>
       <p>
-        我們不是證券投資顧問，也不是什麼受監理的金融機構，沒有提供
-        個別化投資建議或適合度評估。投資前還是請依自己的目標與風險
-        承受度評估，必要時可詢問專業的投顧或稅務顧問。
+        {lang === 'en'
+          ? 'We are not securities investment advisors or a regulated financial institution and provide no personalized advice or suitability assessment. Please evaluate based on your goals and risk tolerance and consult professionals when needed.'
+          : '我們不是證券投資顧問，也不是什麼受監理的金融機構，沒有提供個別化投資建議或適合度評估。投資前還是請依自己的目標與風險承受度評估，必要時可詢問專業的投顧或稅務顧問。'}
       </p>
 
-      <h4>投資風險</h4>
+      <h4>{lang === 'en' ? 'Investment Risks' : '投資風險'}</h4>
       <p>
-        投資一定有風險，ETF/基金淨值會跟著市場上上下下，槓桿和反向
-        商品風險更高，可能讓你賠掉不少本金。過去的績效也不代表未來
-        還會一樣。
+        {lang === 'en'
+          ? 'Investing involves risk. ETF/fund values rise and fall with the market. Leveraged and inverse products carry higher risk and may cause significant losses. Past performance does not guarantee future results.'
+          : '投資一定有風險，ETF/基金淨值會跟著市場上上下下，槓桿和反向商品風險更高，可能讓你賠掉不少本金。過去的績效也不代表未來還會一樣。'}
       </p>
 
-      <h4>資料來源與正確性</h4>
+      <h4>{lang === 'en' ? 'Data Sources & Accuracy' : '資料來源與正確性'}</h4>
       <p>
-        本站使用的報價、配息、日期、頻率、指標和計算結果，來源可能
-        包括台灣證券交易所（TWSE）、公開資訊觀測站（MOPS）、ETF 發行商官網等。
-        這些資料可能有延遲、更新頻率不同、甚至有錯，最終還是以發行機構或官方公告為準。
+        {lang === 'en'
+          ? 'Quotes, dividends, dates, frequencies, metrics and calculations on this site may come from sources such as TWSE, MOPS and ETF issuer websites. Data may be delayed, updated at different frequencies or contain errors. Official sources prevail.'
+          : '本站使用的報價、配息、日期、頻率、指標和計算結果，來源可能包括台灣證券交易所（TWSE）、公開資訊觀測站（MOPS）、ETF 發行商官網等。這些資料可能有延遲、更新頻率不同、甚至有錯，最終還是以發行機構或官方公告為準。'}
       </p>
 
-      <h4>價格與時間基準</h4>
+      <h4>{lang === 'en' ? 'Price & Time Basis' : '價格與時間基準'}</h4>
       <p>
-        除非另有說明，價格通常取最新收盤或延遲行情；除息日、發放日等定義可能因
-        市場或發行機構而有所不同。
+        {lang === 'en'
+          ? 'Unless otherwise noted, prices usually use the latest close or delayed quotes. Definitions of ex-dividend and payment dates may vary by market or issuer.'
+          : '除非另有說明，價格通常取最新收盤或延遲行情；除息日、發放日等定義可能因市場或發行機構而有所不同。'}
       </p>
 
-      <h4>稅務與法遵</h4>
+      <h4>{lang === 'en' ? 'Taxes & Compliance' : '稅務與法遵'}</h4>
       <p>
-        本站不提供稅務或會計建議。配息後實際到手金額會因你的居住地、身份別與當地法規
-        有所差異（例如預扣稅、二代健保等等），請依所在地規定並向專業人士請教。
+        {lang === 'en'
+          ? 'The site does not provide tax or accounting advice. Actual amounts received after dividends depend on your residence, status and local regulations (e.g. withholding tax, NHI). Follow local rules and consult professionals.'
+          : '本站不提供稅務或會計建議。配息後實際到手金額會因你的居住地、身份別與當地法規有所差異（例如預扣稅、二代健保等等），請依所在地規定並向專業人士請教。'}
       </p>
 
-      <h4>第三方連結與合作揭露</h4>
+      <h4>{lang === 'en' ? 'Third-party Links & Disclosure' : '第三方連結與合作揭露'}</h4>
       <p>
-        網站裡可能會出現一些第三方連結或合作（包含推薦連結/廣告）。如果因此有收益，
-        我們會好好揭露，但我們無法保證第三方內容或服務的品質與安全。
+        {lang === 'en'
+          ? 'The site may contain third-party links or partnerships (including referral links/ads). Any revenue will be disclosed, but we cannot guarantee the quality or safety of third-party content or services.'
+          : '網站裡可能會出現一些第三方連結或合作（包含推薦連結/廣告）。如果因此有收益，我們會好好揭露，但我們無法保證第三方內容或服務的品質與安全。'}
       </p>
 
-      <h4>服務中斷與責任限制</h4>
+      <h4>{lang === 'en' ? 'Service Interruptions & Liability' : '服務中斷與責任限制'}</h4>
       <p>
-        本網站可能偶爾因維護、系統故障或不可抗力而暫時中斷或功能受限。
-        使用或無法使用本站所造成的任何損失，我們無法負責。
+        {lang === 'en'
+          ? 'The site may occasionally be interrupted or limited due to maintenance, system failures or force majeure. We are not liable for any losses from using or inability to use the site.'
+          : '本網站可能偶爾因維護、系統故障或不可抗力而暫時中斷或功能受限。使用或無法使用本站所造成的任何損失，我們無法負責。'}
       </p>
 
-      <h4>條款變更</h4>
+      <h4>{lang === 'en' ? 'Changes to Terms' : '條款變更'}</h4>
       <p>
-        我們可能隨時更新這份免責聲明與相關政策，更新後會在頁面公告或透過系統訊息通知。
+        {lang === 'en'
+          ? 'We may update this disclaimer and related policies at any time. Updates will be announced on the page or via system messages.'
+          : '我們可能隨時更新這份免責聲明與相關政策，更新後會在頁面公告或透過系統訊息通知。'}
       </p>
 
       <p>
-        如果你對資料正確性或權利有疑問，歡迎寫信到
-        <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a>
-        和我們聯絡。
+        {lang === 'en'
+          ? <>If you have questions about data accuracy or rights, please email <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a> to contact us.</>
+          : <>如果你對資料正確性或權利有疑問，歡迎寫信到<a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a>和我們聯絡。</>}
       </p>
     </div>
   );

--- a/src/FaqTab.jsx
+++ b/src/FaqTab.jsx
@@ -1,84 +1,127 @@
 import React from 'react';
+import { useLanguage } from './i18n';
 
 export default function FaqTab() {
-  const faqSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: [
-      {
-        '@type': 'Question',
-        name: '殖利率是怎麼算的？',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'TTM 殖利率為過去 12 個月實際配息總額除以最新價格；年度預估殖利率為今年已公告或預估的配息除以最新價格，以發行商公告為準。'
-        }
-      },
-      {
-        '@type': 'Question',
-        name: '除息日和發放日差在哪？',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: '除息日起買進者不享有本次配息；發放日為實際匯入或入帳時間，不同市場規則可能不同。'
-        }
-      },
-      {
-        '@type': 'Question',
-        name: '配息頻率如何定義？',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: '我們依過去紀錄大致分成月配、季配、半年配和年配；若發行商突然調整，分類可能會暫時跟不上。'
-        }
+  const { lang } = useLanguage();
+  const faqSchema = lang === 'en'
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: 'How is dividend yield calculated?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'TTM yield is the total dividends over the past 12 months divided by the latest price; projected annual yield is this year\'s announced or estimated dividends divided by the latest price. Official announcements prevail.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: "What's the difference between ex-dividend and payment dates?",
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Buying on or after the ex-dividend date does not receive the payout; the payment date is when funds actually arrive and may vary by market.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'How is payout frequency defined?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'We roughly categorize based on past records into monthly, quarterly, semiannual and annual payouts; if issuers adjust schedules, classifications may lag.'
+            }
+          }
+        ]
       }
-    ]
-  };
+    : {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: '殖利率是怎麼算的？',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'TTM 殖利率為過去 12 個月實際配息總額除以最新價格；年度預估殖利率為今年已公告或預估的配息除以最新價格，以發行商公告為準。'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: '除息日和發放日差在哪？',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: '除息日起買進者不享有本次配息；發放日為實際匯入或入帳時間，不同市場規則可能不同。'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: '配息頻率如何定義？',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: '我們依過去紀錄大致分成月配、季配、半年配和年配；若發行商突然調整，分類可能會暫時跟不上。'
+            }
+          }
+        ]
+      };
 
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h3 className="mt-4">常見問題（FAQ）</h3>
+      <h3 className="mt-4">{lang === 'en' ? 'FAQ' : '常見問題（FAQ）'}</h3>
 
-      <h4>資料與計算</h4>
+      <h4>{lang === 'en' ? 'Data & Calculations' : '資料與計算'}</h4>
       <ol>
         <li>
-          <strong>殖利率是怎麼算的？</strong>
+          <strong>{lang === 'en' ? 'How is dividend yield calculated?' : '殖利率是怎麼算的？'}</strong>
           <br />
-          常見作法有：
+          {lang === 'en' ? 'Common approaches include:' : '常見作法有：'}
           <ul>
-            <li>TTM 殖利率＝過去 12 個月實際配息總額 ÷ 最新價格</li>
-            <li>年度預估殖利率＝今年已公告配息金額（或近一期預估 × 頻率）÷ 最新價格</li>
+            <li>{lang === 'en' ? 'TTM yield = total dividends over the past 12 months ÷ latest price' : 'TTM 殖利率＝過去 12 個月實際配息總額 ÷ 最新價格'}</li>
+            <li>{lang === 'en' ? 'Projected annual yield = this year\'s announced dividends (or latest estimate × frequency) ÷ latest price' : '年度預估殖利率＝今年已公告配息金額（或近一期預估 × 頻率）÷ 最新價格'}</li>
           </ul>
-          每個頁面都會註明採用的指標，ETF 的配息習慣可能不同，最後還是以發行商公告為準。
+          {lang === 'en'
+            ? 'Each page notes which metric is used. ETF payout habits may differ, so official announcements take precedence.'
+            : '每個頁面都會註明採用的指標，ETF 的配息習慣可能不同，最後還是以發行商公告為準。'}
         </li>
         <li>
-          <strong>除息日和發放日差在哪？</strong>
+          <strong>{lang === 'en' ? "What's the difference between ex-dividend and payment dates?" : '除息日和發放日差在哪？'}</strong>
           <br />
           <ul>
-            <li>除息日：從這天（含）買進就不享有這次配息啦。</li>
-            <li>發放日：實際匯到你帳上的時間，不同市場可能有 T+N 差異。</li>
+            <li>{lang === 'en' ? 'Ex-dividend date: buying on or after this date means you will not receive the dividend.' : '除息日：從這天（含）買進就不享有這次配息啦。'}</li>
+            <li>{lang === 'en' ? 'Payment date: when the funds are actually credited; different markets may have T+N differences.' : '發放日：實際匯到你帳上的時間，不同市場可能有 T+N 差異。'}</li>
           </ul>
         </li>
         <li>
-          <strong>配息頻率如何定義？</strong>
+          <strong>{lang === 'en' ? 'How is payout frequency defined?' : '配息頻率如何定義？'}</strong>
           <br />
-          我們依過去紀錄大致分成月配、季配、半年配和年配；如果發行商突然調整，分類可能會暫時跟不上。
+          {lang === 'en'
+            ? 'We categorize based on past records into monthly, quarterly, semiannual and annual payouts; if issuers change schedules, classifications may temporarily lag.'
+            : '我們依過去紀錄大致分成月配、季配、半年配和年配；如果發行商突然調整，分類可能會暫時跟不上。'}
         </li>
         <li>
-          <strong>槓桿／反向 ETF 有收錄嗎？</strong>
+          <strong>{lang === 'en' ? 'Are leveraged/inverse ETFs included?' : '槓桿／反向 ETF 有收錄嗎？'}</strong>
           <br />
-          偶爾會有，如果收錄會在標的頁明顯標註並附上風險提醒，請多加留意。
+          {lang === 'en'
+            ? 'Occasionally. When included, the page clearly labels them and provides risk warnings.'
+            : '偶爾會有，如果收錄會在標的頁明顯標註並附上風險提醒，請多加留意。'}
         </li>
         <li>
-          <strong>是否支援多市場與多幣別？</strong>
+          <strong>{lang === 'en' ? 'Are multiple markets and currencies supported?' : '是否支援多市場與多幣別？'}</strong>
           <br />
-          支援範圍以網站公告為主；若有多幣別，系統會提供換匯紀錄或匯率欄位供你記錄。
+          {lang === 'en'
+            ? 'Supported range follows what is announced on the site; if multiple currencies exist, the system provides FX records or rate fields for you to log.'
+            : '支援範圍以網站公告為主；若有多幣別，系統會提供換匯紀錄或匯率欄位供你記錄。'}
         </li>
       </ol>
 
-      <h4>聯絡我們</h4>
+      <h4>{lang === 'en' ? 'Contact Us' : '聯絡我們'}</h4>
       <ol start={7}>
         <li>
-          <strong>如何報告錯誤或建議新功能？</strong>
+          <strong>{lang === 'en' ? 'How can I report errors or suggest features?' : '如何報告錯誤或建議新功能？'}</strong>
           <br />
-          歡迎寄信到 <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a>；若是資料更正，記得附上連結或佐證。
+          {lang === 'en'
+            ? <>Feel free to email <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a>; for data corrections, please include links or proof.</>
+            : <>歡迎寄信到 <a href="mailto:giantbean2025@gmail.com">giantbean2025@gmail.com</a>；若是資料更正，記得附上連結或佐證。</>}
         </li>
       </ol>
       <script

--- a/src/GuideTab.jsx
+++ b/src/GuideTab.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
+import { useLanguage } from './i18n';
 
 export default function GuideTab() {
+  const { lang } = useLanguage();
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h3 className="mt-4">使用小幫手</h3>
+      <h3 className="mt-4">{lang === 'en' ? 'User Guide' : '使用小幫手'}</h3>
       <p>
-        以下說明目前提供的公開資訊瀏覽功能，先玩玩現有功能，未來有新工具再慢慢上線囉。
+        {lang === 'en'
+          ? 'Below is an introduction to the current public information features. Feel free to play with them; new tools will come later.'
+          : '以下說明目前提供的公開資訊瀏覽功能，先玩玩現有功能，未來有新工具再慢慢上線囉。'}
       </p>
-      <h4>瀏覽 ETF 與配息資訊</h4>
+      <h4>{lang === 'en' ? 'Browse ETF and Dividend Info' : '瀏覽 ETF 與配息資訊'}</h4>
       <ol>
         <li>
-          <strong>搜尋與篩選</strong>
+          <strong>{lang === 'en' ? 'Search and Filter' : '搜尋與篩選'}</strong>
           <br />
-          在首頁或清單頁輸入代號／名稱，搭配篩選器（市場、配息頻率、殖利率區間、規模等）就能迅速縮小範圍。
+          {lang === 'en'
+            ? 'Enter the symbol or name on the home or list page and use filters (market, payout frequency, yield range, size, etc.) to narrow it down quickly.'
+            : '在首頁或清單頁輸入代號／名稱，搭配篩選器（市場、配息頻率、殖利率區間、規模等）就能迅速縮小範圍。'}
         </li>
         <li>
-          <strong>ETF 詳細頁</strong>
+          <strong>{lang === 'en' ? 'ETF Detail Page' : 'ETF 詳細頁'}</strong>
           <br />
-          可查看配息歷史（除息日、發放日、每單位配息）、殖利率指標（如 TTM/年度預估）、基本資料（成立日、規模）。
+          {lang === 'en'
+            ? 'View dividend history (ex-date, payment date, per-unit payout), yield indicators (such as TTM/annual estimate), and basic info (inception date, size).'
+            : '可查看配息歷史（除息日、發放日、每單位配息）、殖利率指標（如 TTM/年度預估）、基本資料（成立日、規模）。'}
         </li>
       </ol>
     </div>

--- a/src/NLHelper.jsx
+++ b/src/NLHelper.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { API_HOST } from './config';
 import { fetchWithCache } from './api';
+import { useLanguage } from './i18n';
 
 function NLHelper() {
+  const { lang } = useLanguage();
   const [query, setQuery] = useState('');
   const [response, setResponse] = useState('');
   const [loading, setLoading] = useState(false);
@@ -32,10 +34,10 @@ function NLHelper() {
         <textarea
           value={query}
           onChange={e => setQuery(e.target.value)}
-          placeholder="輸入查詢..."
+          placeholder={lang === 'en' ? 'Enter query...' : '輸入查詢...'}
         />
         <button onClick={handleSubmit} disabled={loading}>
-          {loading ? '查詢中...' : '送出'}
+          {loading ? (lang === 'en' ? 'Searching...' : '查詢中...') : (lang === 'en' ? 'Submit' : '送出')}
         </button>
         <pre className="nl-helper-response">{response}</pre>
       </div>

--- a/src/PrivacyPolicyTab.jsx
+++ b/src/PrivacyPolicyTab.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { useLanguage } from './i18n';
 
 export default function PrivacyPolicyTab() {
+  const { lang } = useLanguage();
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h3 className="mt-4">隱私權政策</h3>
+      <h3 className="mt-4">{lang === 'en' ? 'Privacy Policy' : '隱私權政策'}</h3>
       <p>
-        本站尊重並保護您的個人資料，僅蒐集提供服務所必需的資訊。您可隨時查詢、下載、
-        更正或刪除自己的資料，詳細內容請參考本政策。
+        {lang === 'en'
+          ? 'We respect and protect your personal data, collecting only information necessary to provide services. You may query, download, correct or delete your data at any time. See this policy for details.'
+          : '本站尊重並保護您的個人資料，僅蒐集提供服務所必需的資訊。您可隨時查詢、下載、 更正或刪除自己的資料，詳細內容請參考本政策。'}
       </p>
     </div>
   );

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -3,8 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { API_HOST } from './config';
 import './App.css';
 import Footer from './components/Footer';
+import { useLanguage } from './i18n';
 
 export default function StockDetail({ stockId }) {
+  const { lang } = useLanguage();
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark');
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
@@ -62,11 +64,11 @@ export default function StockDetail({ stockId }) {
   }, [dividendList, stockId]);
 
   if (stockLoading || dividendLoading || returnsLoading) {
-    return <div>載入中...</div>;
+    return <div>{lang === 'en' ? 'Loading...' : '載入中...'}</div>;
   }
 
   if (!stock.stock_id) {
-    return <div style={{ padding: 20 }}>找不到股票</div>;
+    return <div style={{ padding: 20 }}>{lang === 'en' ? 'Stock not found' : '找不到股票'}</div>;
   }
 
   const website = stock.website;
@@ -77,44 +79,44 @@ export default function StockDetail({ stockId }) {
       <h3>{stock.stock_id} {stock.stock_name}</h3>
       {stockUpdatedAt && (
         <div style={{ textAlign: 'right', fontSize: 12 }}>
-          資料更新時間: {new Date(stockUpdatedAt).toLocaleString()}
+          {lang === 'en' ? 'Data updated at:' : '資料更新時間:'} {new Date(stockUpdatedAt).toLocaleString()}
         </div>
       )}
-      <p>配息頻率: {stock.dividend_frequency || '-'}</p>
-      <p>保管銀行: {stock.custodian || '-'}</p>
-      <p>發行券商: {stock.issuer || '-'}</p>
-      <p>ETF規模: {stock.assets || '-'}</p>
+      <p>{lang === 'en' ? 'Dividend frequency:' : '配息頻率:'} {stock.dividend_frequency || '-'}</p>
+      <p>{lang === 'en' ? 'Custodian bank:' : '保管銀行:'} {stock.custodian || '-'}</p>
+      <p>{lang === 'en' ? 'Issuer:' : '發行券商:'} {stock.issuer || '-'}</p>
+      <p>{lang === 'en' ? 'ETF size:' : 'ETF規模:'} {stock.assets || '-'}</p>
       <p>
-        官網: {website ? (
+        {lang === 'en' ? 'Website:' : '官網:'} {website ? (
           <a href={website} target="_blank" rel="noreferrer" style={{ wordBreak: 'break-all' }}>{website}</a>
         ) : (
           '-'
         )}
       </p>
-      <p>上市日期: {stock.listing_date || '-'}</p>
+      <p>{lang === 'en' ? 'Listing date:' : '上市日期:'} {stock.listing_date || '-'}</p>
       {returns.stock_id && (
         <div className="table-responsive">
           <table className="dividend-record">
             <thead>
                 <tr>
                   <th></th>
-                  <th>價差(不含息)</th>
-                  <th>績效(含息)</th>
+                  <th>{lang === 'en' ? 'Price Return (ex-div)' : '價差(不含息)'}</th>
+                  <th>{lang === 'en' ? 'Total Return (incl. div)' : '績效(含息)'}</th>
                 </tr>
             </thead>
             <tbody>
               <tr>
-                <td>近1月</td>
+                <td>{lang === 'en' ? '1M' : '近1月'}</td>
                 <td>{returns.price_return_1m}%</td>
                 <td>{returns.total_return_1m}%</td>
               </tr>
               <tr>
-                <td>近3月</td>
+                <td>{lang === 'en' ? '3M' : '近3月'}</td>
                 <td>{returns.price_return_3m}%</td>
                 <td>{returns.total_return_3m}%</td>
               </tr>
               <tr>
-                <td>近1年</td>
+                <td>{lang === 'en' ? '1Y' : '近1年'}</td>
                 <td>{returns.price_return_1y}%</td>
                 <td>{returns.total_return_1y}%</td>
               </tr>
@@ -123,25 +125,27 @@ export default function StockDetail({ stockId }) {
         </div>
       )}
       <ul className="link-list">
-        <li>資料來源：<a href={`https://www.cmoney.tw/etf/tw/${stockId}/intro`} target="_blank" rel="noreferrer">CMoney ETF介紹</a>（外部網站）</li>
-        <li>資料來源：<a href={`https://www.moneydj.com/etf/x/basic/basic0003.xdjhtm?etfid=${stockId}.tw`} target="_blank" rel="noreferrer">MoneyDJ 基本資料</a>（外部網站）</li>
-        <li>資料來源：<a href={`https://goodinfo.tw/tw/StockDetail.asp?STOCK_ID=${stockId}`} target="_blank" rel="noreferrer">Goodinfo 股市資訊</a>（外部網站）</li>
-        <li>資料來源：<a href={`https://tw.stock.yahoo.com/quote/${stockId}.TW`} target="_blank" rel="noreferrer">Yahoo 股價</a>（外部網站）</li>
-        <li>資料來源：<a href={`https://histock.tw/stock/${stockId}`} target="_blank" rel="noreferrer">HiStock 個股資訊</a>（外部網站）</li>
-        <li>資料來源：<a href={`https://www.cnyes.com/twstock/${stockId}`} target="_blank" rel="noreferrer">鉅亨網 個股資訊</a>（外部網站）</li>
-        <li>資料來源：<a href={`https://www.stockq.org/etf/${stockId}.php`} target="_blank" rel="noreferrer">StockQ ETF資料</a>（外部網站）</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://www.cmoney.tw/etf/tw/${stockId}/intro`} target="_blank" rel="noreferrer">{lang === 'en' ? 'CMoney ETF Intro' : 'CMoney ETF介紹'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://www.moneydj.com/etf/x/basic/basic0003.xdjhtm?etfid=${stockId}.tw`} target="_blank" rel="noreferrer">{lang === 'en' ? 'MoneyDJ Basic Info' : 'MoneyDJ 基本資料'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://goodinfo.tw/tw/StockDetail.asp?STOCK_ID=${stockId}`} target="_blank" rel="noreferrer">{lang === 'en' ? 'Goodinfo Stock Info' : 'Goodinfo 股市資訊'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://tw.stock.yahoo.com/quote/${stockId}.TW`} target="_blank" rel="noreferrer">{lang === 'en' ? 'Yahoo Price' : 'Yahoo 股價'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://histock.tw/stock/${stockId}`} target="_blank" rel="noreferrer">{lang === 'en' ? 'HiStock Info' : 'HiStock 個股資訊'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://www.cnyes.com/twstock/${stockId}`} target="_blank" rel="noreferrer">{lang === 'en' ? 'Cnyes Stock Info' : '鉅亨網 個股資訊'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
+        <li>{lang === 'en' ? 'Data source:' : '資料來源：'}<a href={`https://www.stockq.org/etf/${stockId}.php`} target="_blank" rel="noreferrer">{lang === 'en' ? 'StockQ ETF Data' : 'StockQ ETF資料'}</a>{lang === 'en' ? ' (external site)' : '（外部網站）'}</li>
       </ul>
       <p className="disclaimer">
-        以上連結皆為第三方外部網站，資料內容由各網站提供，本網站不對其正確性負責。
+        {lang === 'en'
+          ? 'The above links are third-party sites. Data is provided by those sites and we are not responsible for its accuracy.'
+          : '以上連結皆為第三方外部網站，資料內容由各網站提供，本網站不對其正確性負責。'}
       </p>
       {dividends.length > 0 && (
         <div className="table-responsive">
           <table className="dividend-record">
             <thead>
               <tr>
-                <th>日期</th>
-                <th>配息金額</th>
-                <th>利率</th>
+                <th>{lang === 'en' ? 'Date' : '日期'}</th>
+                <th>{lang === 'en' ? 'Dividend' : '配息金額'}</th>
+                <th>{lang === 'en' ? 'Yield' : '利率'}</th>
               </tr>
             </thead>
             <tbody>

--- a/src/TermsOfServiceTab.jsx
+++ b/src/TermsOfServiceTab.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { useLanguage } from './i18n';
 
 export default function TermsOfServiceTab() {
+  const { lang } = useLanguage();
   return (
     <div className="container" style={{ maxWidth: 800 }}>
-      <h3 className="mt-4">服務條款</h3>
+      <h3 className="mt-4">{lang === 'en' ? 'Terms of Service' : '服務條款'}</h3>
       <p>
-        使用本服務即表示您同意遵守本站規範，包含使用者義務、智慧財產權與責任限制等。
-        任何爭議將依相關法律處理。
+        {lang === 'en'
+          ? 'By using this service you agree to follow site rules, including user obligations, intellectual property rights and liability limits. Any disputes will be handled according to applicable laws.'
+          : '使用本服務即表示您同意遵守本站規範，包含使用者義務、智慧財產權與責任限制等。任何爭議將依相關法律處理。'}
       </p>
     </div>
   );

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -2,11 +2,8 @@ import { useState, useEffect } from 'react';
 import DividendCalendar from './components/DividendCalendar';
 import { readTransactionHistory } from './transactionStorage';
 import { API_HOST } from './config';
+import { useLanguage } from './i18n';
 
-const MONTHS = [
-    '1月', '2月', '3月', '4月', '5月', '6月',
-    '7月', '8月', '9月', '10月', '11月', '12月'
-];
 const MONTH_COL_WIDTH = 80;
 function getTransactionHistory() {
     return readTransactionHistory().map(item => ({
@@ -18,6 +15,10 @@ function getTransactionHistory() {
 }
 
 export default function UserDividendsTab({ allDividendData, selectedYear }) {
+    const { lang } = useLanguage();
+    const MONTHS = lang === 'en'
+        ? ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        : ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
     const [history, setHistory] = useState([]);
     const [showCalendar, setShowCalendar] = useState(true);
     // Default to showing both ex-dividend and payment events
@@ -196,13 +197,13 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     return (
         <div className="App" style={{ margin: '0 auto' }}>
             <div style={{ display: "flex", alignItems: "center", margin: "10px 0 0 0", gap: "8px"}}>
-                <h3>{selectedYear} 配息總覽</h3>
+                <h3>{selectedYear} {lang === 'en' ? 'Dividend Overview' : '配息總覽'}</h3>
             </div>
             <div style={{ margin: '10px 0' }}>
                 <button
                     onClick={() => setShowCalendar(v => !v)}
                 >
-                    {showCalendar ? '隱藏月曆' : '顯示月曆'}
+                    {showCalendar ? (lang === 'en' ? 'Hide Calendar' : '隱藏月曆') : (lang === 'en' ? 'Show Calendar' : '顯示月曆')}
                 </button>
             </div>
 
@@ -213,21 +214,21 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                             onClick={() => setCalendarFilter('ex')}
                             className={calendarFilter === 'ex' ? 'btn-selected' : 'btn-unselected'}
                         >
-                            除息日
+                            {lang === 'en' ? 'Ex-dividend Date' : '除息日'}
                         </button>
                         <button
                             onClick={() => setCalendarFilter('pay')}
                             className={calendarFilter === 'pay' ? 'btn-selected' : 'btn-unselected'}
                             style={{ marginLeft: 6 }}
                         >
-                            發放日
+                            {lang === 'en' ? 'Payment Date' : '發放日'}
                         </button>
                         <button
                             onClick={() => setCalendarFilter('both')}
                             className={calendarFilter === 'both' ? 'btn-selected' : 'btn-unselected'}
                             style={{ marginLeft: 6 }}
                         >
-                            除息/發放日
+                            {lang === 'en' ? 'Ex/Paid Date' : '除息/發放日'}
                         </button>
                     </div>
                     <DividendCalendar year={selectedYear} events={filteredCalendarEvents} showTotals />
@@ -240,7 +241,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     <tr>
                         <th className="stock-col">
                             <span className="sortable" onClick={() => handleSort('stock_id')}>
-                                股票代碼/名稱
+                                {lang === 'en' ? 'Ticker/Name' : '股票代碼/名稱'}
                                 {sortConfig.column === 'stock_id' && (
                                     <span className="sort-indicator">{sortConfig.direction === 'asc' ? '▲' : '▼'}</span>
                                 )}
@@ -248,7 +249,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                         </th>
                         <th>
                             <span className="sortable" onClick={() => handleSort('total')}>
-                                總計
+                                {lang === 'en' ? 'Total' : '總計'}
                                 {sortConfig.column === 'total' && (
                                     <span className="sort-indicator">{sortConfig.direction === 'asc' ? '▲' : '▼'}</span>
                                 )}
@@ -269,7 +270,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                 <tbody>
                     {sortedStocks.length === 0 ? (
                         <tr>
-                            <td colSpan={14}>尚無庫存，請先新增交易紀錄</td>
+                            <td colSpan={14}>{lang === 'en' ? 'No holdings, please add transactions first' : '尚無庫存，請先新增交易紀錄'}</td>
                         </tr>
                     ) : (
                         sortedStocks.map(stock => (
@@ -284,7 +285,9 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                     const estAnnual = avgYield * 12;
                                     return (
                                         <span
-                                            title={`最新收盤價: ${latestClosePrice[stock.stock_id]?.price || '-'}\n加總殖利率: ${totalYield[stock.stock_id].toFixed(1)}%\n預估年化殖利率: ${estAnnual.toFixed(1)}%`}
+                                            title={lang === 'en'
+                                                ? `Latest close: ${latestClosePrice[stock.stock_id]?.price || '-'}\nSum yield: ${totalYield[stock.stock_id].toFixed(1)}%\nEst. annual yield: ${estAnnual.toFixed(1)}%`
+                                                : `最新收盤價: ${latestClosePrice[stock.stock_id]?.price || '-'}\n加總殖利率: ${totalYield[stock.stock_id].toFixed(1)}%\n預估年化殖利率: ${estAnnual.toFixed(1)}%`}
                                             style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
                                         >
                                             {Math.round(totalPerStock[stock.stock_id]).toLocaleString()}
@@ -298,7 +301,9 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                     return (
                                         <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>
                                             <span
-                                                title={`持有數量: ${cell.quantity} 股 (${(cell.quantity / 1000).toFixed(3).replace(/\.?0+$/, '')} 張)\n每股配息: ${cell.dividend} 元\n除息前一天收盤價: ${cell.last_close_price}\n當次殖利率: ${cell.dividend_yield}\n配息日期: ${cell.dividend_date || '-'}\n發放日期: ${cell.payment_date || '-'}`}
+                                                title={lang === 'en'
+                                                    ? `Shares held: ${cell.quantity} (${(cell.quantity / 1000).toFixed(3).replace(/\.?0+$/, '')} lots)\nDividend per share: ${cell.dividend} \nClose before ex-date: ${cell.last_close_price}\nYield this time: ${cell.dividend_yield}\nEx-dividend date: ${cell.dividend_date || '-'}\nPayment date: ${cell.payment_date || '-'}`
+                                                    : `持有數量: ${cell.quantity} 股 (${(cell.quantity / 1000).toFixed(3).replace(/\.?0+$/, '')} 張)\n每股配息: ${cell.dividend} 元\n除息前一天收盤價: ${cell.last_close_price}\n當次殖利率: ${cell.dividend_yield}\n配息日期: ${cell.dividend_date || '-'}\n發放日期: ${cell.payment_date || '-'}`}
                                                 style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
                                             >
                                                 {total > 0 ? Math.round(total).toLocaleString() : ''}
@@ -310,11 +315,13 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                         ))
                     )}
                     <tr style={{ background: '#ffe066', fontWeight: 'bold' }}>
-                        <td>月合計</td>
+                        <td>{lang === 'en' ? 'Monthly Total' : '月合計'}</td>
                         <td>
                             {grandTotal > 0 ? (
                                 <span
-                                    title={`每月平均領取: ${Math.round(avgPerMonth).toLocaleString()}`}
+                                    title={lang === 'en'
+                                        ? `Average per month: ${Math.round(avgPerMonth).toLocaleString()}`
+                                        : `每月平均領取: ${Math.round(avgPerMonth).toLocaleString()}`}
                                     style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
                                 >
                                     {Math.round(grandTotal).toLocaleString()}
@@ -329,7 +336,9 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
             </table>
             </div>
             <p style={{ fontSize: 12, marginTop: 8, color: '#666' }}>
-                提示：滑鼠移到數字可看持股、每股配息及日期、價格與殖利率細節。
+                {lang === 'en'
+                    ? 'Tip: hover numbers to see holdings, per-share dividends, dates, prices and yield details.'
+                    : '提示：滑鼠移到數字可看持股、每股配息及日期、價格與殖利率細節。'}
             </p>
         </div>
     );


### PR DESCRIPTION
## Summary
- add language toggles and English copy across About, FAQ, Disclaimer, Terms, Privacy and dividend pages
- translate stock detail view and NL helper to show English UI when selected
- allow dividend overview table and calendar controls to switch between Chinese and English

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3eede0fb88329bdffb220e4880ea4