### PR TITLE
feat: add English support for components

### DIFF
--- a/src/components/AddTransactionModal.jsx
+++ b/src/components/AddTransactionModal.jsx
@@ -1,5 +1,6 @@
 import Select from 'react-select';
 import styles from './AddTransactionModal.module.css';
+import { useLanguage } from '../i18n';
 
 const selectStyles = {
   control: provided => ({
@@ -30,6 +31,7 @@ const selectStyles = {
 };
 
 export default function AddTransactionModal({ show, onClose, stockList, form, setForm, onSubmit }) {
+  const { lang } = useLanguage();
   if (!show) return null;
   const options = stockList.map(s => ({
     value: s.stock_id,
@@ -41,10 +43,10 @@ export default function AddTransactionModal({ show, onClose, stockList, form, se
   return (
     <div className={styles.overlay}>
       <div className={styles.modal}>
-        <h5 className={styles.title}>新增購買紀錄</h5>
+        <h5 className={styles.title}>{lang === 'en' ? 'Add Purchase Record' : '新增購買紀錄'}</h5>
         <div className={styles.form}>
           <div className={styles.formGroup}>
-            <label className={styles.label}>股票：</label>
+            <label className={styles.label}>{lang === 'en' ? 'Stock:' : '股票：'}</label>
             <div className={styles.inputWrapper}>
               <Select
                 options={options}
@@ -57,14 +59,14 @@ export default function AddTransactionModal({ show, onClose, stockList, form, se
                     stock_name: stock ? stock.stock_name : ''
                   }));
                 }}
-                placeholder="搜尋或選擇股票"
+                placeholder={lang === 'en' ? 'Search or select stock' : '搜尋或選擇股票'}
                 isClearable
                 styles={selectStyles}                     // ⬅️ apply custom styles
               />
             </div>
           </div>
           <div className={styles.formGroup}>
-            <label className={styles.label}>購買日期：</label>
+            <label className={styles.label}>{lang === 'en' ? 'Purchase Date:' : '購買日期：'}</label>
             <input
               type="date"
               value={form.date}
@@ -74,7 +76,7 @@ export default function AddTransactionModal({ show, onClose, stockList, form, se
             />
           </div>
           <div className={styles.formGroup}>
-            <label className={styles.label}>數量（股）：</label>
+            <label className={styles.label}>{lang === 'en' ? 'Quantity (shares):' : '數量（股）：'}</label>
             <input
               type="number"
               min={1000}
@@ -86,7 +88,7 @@ export default function AddTransactionModal({ show, onClose, stockList, form, se
             />
           </div>
           <div className={styles.formGroup}>
-            <label className={styles.label}>價格（元）：</label>
+            <label className={styles.label}>{lang === 'en' ? 'Price (NT$):' : '價格（元）：'}</label>
             <input
               type="number"
               min={0}
@@ -99,8 +101,8 @@ export default function AddTransactionModal({ show, onClose, stockList, form, se
           </div>
         </div>
         <div className={styles.buttonRow}>
-          <button onClick={onSubmit} className={styles.primaryButton}>儲存</button>
-          <button onClick={onClose} className={styles.secondaryButton}>關閉</button>
+          <button onClick={onSubmit} className={styles.primaryButton}>{lang === 'en' ? 'Save' : '儲存'}</button>
+          <button onClick={onClose} className={styles.secondaryButton}>{lang === 'en' ? 'Close' : '關閉'}</button>
         </div>
       </div>
     </div>

--- a/src/components/AdvancedFilterDropdown.jsx
+++ b/src/components/AdvancedFilterDropdown.jsx
@@ -1,9 +1,11 @@
 import { useState, useRef } from 'react';
 import useClickOutside from './useClickOutside';
+import { useLanguage } from '../i18n';
 
 export default function AdvancedFilterDropdown({ filters, setFilters, onClose }) {
   const ref = useRef();
   useClickOutside(ref, onClose);
+  const { lang } = useLanguage();
 
   const [temp, setTemp] = useState(filters);
 
@@ -27,7 +29,7 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
     <div className="dropdown" ref={ref} style={{ padding: 8, zIndex: 9999 }}>
       <div className="dropdown-section">
         <label>
-          預估殖利率 ≥
+          {lang === 'en' ? 'Estimated yield ≥' : '預估殖利率 ≥'}
           <input
             type="number"
             value={temp.minYield}
@@ -38,13 +40,13 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
       </div>
       <hr />
       <div className="dropdown-section" style={{ maxHeight: 100, overflowY: 'auto' }}>
-        {[{ v: 12, l: '月配' }, { v: 6, l: '雙月配' }, { v: 4, l: '季配' }, { v: 2, l: '半年配' }, { v: 1, l: '年配' }].map(opt => (
+        {[{ v: 12, zh: '月配', en: 'Monthly' }, { v: 6, zh: '雙月配', en: 'Bimonthly' }, { v: 4, zh: '季配', en: 'Quarterly' }, { v: 2, zh: '半年配', en: 'Semi-annual' }, { v: 1, zh: '年配', en: 'Annual' }].map(opt => (
           <label key={opt.v} className="dropdown-item">
             <input
               type="checkbox"
               checked={temp.freq.includes(opt.v)}
               onChange={() => toggleFreq(opt.v)}
-            /> {opt.l}
+            /> {lang === 'en' ? opt.en : opt.zh}
           </label>
         ))}
       </div>
@@ -55,24 +57,24 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
             type="checkbox"
             checked={temp.diamond}
             onChange={e => setTemp({ ...temp, diamond: e.target.checked })}
-          /> 只顯示鑽石
+          /> {lang === 'en' ? 'Show only diamonds' : '只顯示鑽石'}
         </label>
       </div>
       <hr />
       <div className="dropdown-section">
         <label>
-          即將除息/發息：未來
+          {lang === 'en' ? 'Upcoming ex/payout within' : '即將除息/發息：未來'}
           <input
             type="number"
             value={temp.upcomingWithin}
             onChange={e => setTemp({ ...temp, upcomingWithin: e.target.value })}
             style={{ width: 60, margin: '0 4px' }}
-          />天內
+          />{lang === 'en' ? 'days' : '天內'}
         </label>
       </div>
       <div style={{ marginTop: 8, textAlign: 'right' }}>
-        <button className="dropdown-btn" onClick={handleClear}>清除</button>
-        <button className="dropdown-btn" style={{ marginLeft: 8 }} onClick={handleApply}>確定</button>
+        <button className="dropdown-btn" onClick={handleClear}>{lang === 'en' ? 'Clear' : '清除'}</button>
+        <button className="dropdown-btn" style={{ marginLeft: 8 }} onClick={handleApply}>{lang === 'en' ? 'Apply' : '確定'}</button>
       </div>
     </div>
   );

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
 import Cookies from 'js-cookie';
 import './CookieConsent.css';
+import { useLanguage } from '../i18n';
 
 const COOKIE_NAME = 'cookie_consent';
 
 export default function CookieConsent() {
   const [visible, setVisible] = useState(false);
+  const { lang } = useLanguage();
 
   useEffect(() => {
     const consent = Cookies.get(COOKIE_NAME);
@@ -24,9 +26,11 @@ export default function CookieConsent() {
   return (
     <div className="cookie-consent">
       <span>
-        本網站使用 Cookie 以提升使用者體驗。繼續瀏覽表示您同意我們使用 Cookie。
+        {lang === 'en'
+          ? 'This site uses cookies to enhance your experience. By continuing to browse, you agree to our use of cookies.'
+          : '本網站使用 Cookie 以提升使用者體驗。繼續瀏覽表示您同意我們使用 Cookie。'}
       </span>
-      <button onClick={accept}>知道了！</button>
+      <button onClick={accept}>{lang === 'en' ? 'Got it!' : '知道了！'}</button>
     </div>
   );
 }

--- a/src/components/DataDropdown.jsx
+++ b/src/components/DataDropdown.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import useClickOutside from './useClickOutside';
 import styles from '../InventoryTab.module.css';
+import { useLanguage } from '../i18n';
 
 export default function DataDropdown({
   onClose,
@@ -17,6 +18,7 @@ export default function DataDropdown({
 }) {
   const ref = useRef();
   useClickOutside(ref, onClose);
+  const { lang } = useLanguage();
 
   const handleAction = action => {
     action();
@@ -28,36 +30,36 @@ export default function DataDropdown({
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>CSV</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleImportClick)}>匯入</button>
-          <button onClick={() => handleAction(handleExportClick)}>匯出</button>
+          <button onClick={() => handleAction(handleImportClick)}>{lang === 'en' ? 'Import' : '匯入'}</button>
+          <button onClick={() => handleAction(handleExportClick)}>{lang === 'en' ? 'Export' : '匯出'}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>Google Drive</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleDriveImport)}>匯入</button>
-          <button onClick={() => handleAction(handleDriveExport)}>匯出</button>
+          <button onClick={() => handleAction(handleDriveImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
+          <button onClick={() => handleAction(handleDriveExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>Dropbox</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleDropboxImport)}>匯入</button>
-          <button onClick={() => handleAction(handleDropboxExport)}>匯出</button>
+          <button onClick={() => handleAction(handleDropboxImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
+          <button onClick={() => handleAction(handleDropboxExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>OneDrive</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleOneDriveImport)}>匯入</button>
-          <button onClick={() => handleAction(handleOneDriveExport)}>匯出</button>
+          <button onClick={() => handleAction(handleOneDriveImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
+          <button onClick={() => handleAction(handleOneDriveExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>iCloudDrive</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleICloudImport)}>匯入</button>
-          <button onClick={() => handleAction(handleICloudExport)}>匯出</button>
+          <button onClick={() => handleAction(handleICloudImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
+          <button onClick={() => handleAction(handleICloudExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
         </div>
       </div>
     </div>

--- a/src/components/DisplayDropdown.jsx
+++ b/src/components/DisplayDropdown.jsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import useClickOutside from './useClickOutside';
+import { useLanguage } from '../i18n';
 
 export default function DisplayDropdown({
   toggleDividendYield,
@@ -10,6 +11,7 @@ export default function DisplayDropdown({
 }) {
   const ref = useRef();
   useClickOutside(ref, onClose);
+  const { lang } = useLanguage();
 
   const handleClick = (action) => {
     action();
@@ -19,10 +21,10 @@ export default function DisplayDropdown({
   return (
       <div className="action-dropdown silver-button-container" ref={ref}>
         <button onClick={() => handleClick(toggleDividendYield)}>
-          {showDividendYield ? '顯示配息' : '顯示殖利率'}
+          {showDividendYield ? (lang === 'en' ? 'Show Dividends' : '顯示配息') : (lang === 'en' ? 'Show Yield' : '顯示殖利率')}
         </button>
         <button onClick={() => handleClick(toggleAxis)}>
-          {showInfoAxis ? '顯示月份' : '顯示資訊'}
+          {showInfoAxis ? (lang === 'en' ? 'Show Months' : '顯示月份') : (lang === 'en' ? 'Show Info' : '顯示資訊')}
         </button>
       </div>
   );

--- a/src/components/FilterDropdown.jsx
+++ b/src/components/FilterDropdown.jsx
@@ -1,9 +1,11 @@
 import { useState, useRef } from 'react';
 import useClickOutside from './useClickOutside';
+import { useLanguage } from '../i18n';
 
 export default function FilterDropdown({ options, selected, setSelected, onClose }) {
   const ref = useRef();
   useClickOutside(ref, onClose);
+  const { lang } = useLanguage();
 
   const [tempSelected, setTempSelected] = useState(selected);
   const [searchText, setSearchText] = useState('');
@@ -43,7 +45,7 @@ export default function FilterDropdown({ options, selected, setSelected, onClose
         className="dropdown-search"
         value={searchText}
         onChange={e => setSearchText(e.target.value)}
-        placeholder="搜尋..."
+        placeholder={lang === 'en' ? 'Search...' : '搜尋...'}
         autoFocus
       />
       <div style={{ maxHeight: 180, overflowY: 'auto', marginTop: 6 }}>
@@ -56,11 +58,13 @@ export default function FilterDropdown({ options, selected, setSelected, onClose
             }
             onChange={handleAll}
           />
-          <span style={{ fontWeight: 'bold', marginLeft: 5 }}>全選</span>
+          <span style={{ fontWeight: 'bold', marginLeft: 5 }}>{lang === 'en' ? 'Select All' : '全選'}</span>
         </label>
         <hr />
         {filteredOptions.length === 0 && (
-          <div style={{ color: '#bbb', padding: '8px 0', fontSize: 13 }}>無符合選項</div>
+          <div style={{ color: '#bbb', padding: '8px 0', fontSize: 13 }}>
+            {lang === 'en' ? 'No matching options' : '無符合選項'}
+          </div>
         )}
         {filteredOptions.map(opt => (
           <label key={opt.value} className="dropdown-item">
@@ -73,8 +77,8 @@ export default function FilterDropdown({ options, selected, setSelected, onClose
         ))}
       </div>
       <div style={{ marginTop: 8, textAlign: 'right' }}>
-        <button className="dropdown-btn" onClick={handleClear}>清除</button>
-        <button className="dropdown-btn" style={{ marginLeft: 8 }} onClick={handleApply}>確定</button>
+        <button className="dropdown-btn" onClick={handleClear}>{lang === 'en' ? 'Clear' : '清除'}</button>
+        <button className="dropdown-btn" style={{ marginLeft: 8 }} onClick={handleApply}>{lang === 'en' ? 'Apply' : '確定'}</button>
       </div>
     </div>
   );

--- a/src/components/SellModal.jsx
+++ b/src/components/SellModal.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
 import styles from './SellModal.module.css';
+import { useLanguage } from '../i18n';
 
 export default function SellModal({ show, stock, onClose, onSubmit }) {
+  const { lang } = useLanguage();
   const [quantity, setQuantity] = useState(1);
   useEffect(() => {
     if (stock) setQuantity(stock.total_quantity);
@@ -10,10 +12,10 @@ export default function SellModal({ show, stock, onClose, onSubmit }) {
   return (
     <div className={styles.overlay}>
       <div className={styles.modal}>
-        <h5 className={styles.title}>賣出股票</h5>
-        <p className={styles.text}>股票：{stock.stock_id} - {stock.stock_name}</p>
+        <h5 className={styles.title}>{lang === 'en' ? 'Sell Stock' : '賣出股票'}</h5>
+        <p className={styles.text}>{lang === 'en' ? 'Stock:' : '股票：'}{stock.stock_id} - {stock.stock_name}</p>
         <div className={styles.formGroup}>
-          <label className={styles.label}>賣出數量：</label>
+          <label className={styles.label}>{lang === 'en' ? 'Sell Quantity:' : '賣出數量：'}</label>
           <input
             type="number"
             min={1}
@@ -31,8 +33,8 @@ export default function SellModal({ show, stock, onClose, onSubmit }) {
           />
         </div>
         <div className={styles.buttonRow}>
-          <button onClick={() => { onSubmit(stock.stock_id, quantity); }} className={styles.primaryButton}>確認</button>
-          <button onClick={onClose} className={styles.secondaryButton}>關閉</button>
+          <button onClick={() => { onSubmit(stock.stock_id, quantity); }} className={styles.primaryButton}>{lang === 'en' ? 'Confirm' : '確認'}</button>
+          <button onClick={onClose} className={styles.secondaryButton}>{lang === 'en' ? 'Close' : '關閉'}</button>
         </div>
       </div>
     </div>

--- a/src/components/TransactionHistoryTable.jsx
+++ b/src/components/TransactionHistoryTable.jsx
@@ -1,23 +1,25 @@
 import styles from './TransactionHistoryTable.module.css';
 import { API_HOST } from '../config';
+import { useLanguage } from '../i18n';
 
 export default function TransactionHistoryTable({ transactionHistory, stockList, editingIdx, editForm, setEditForm, setEditingIdx, handleEditSave, handleDelete }) {
+  const { lang } = useLanguage();
   return (
     <div className="table-responsive">
       <table className={`table table-bordered table-striped ${styles.table}`}>
         <thead>
           <tr>
-            <th className="stock-col">股票代碼/名稱</th>
-            <th>交易日期</th>
-            <th>數量(股)</th>
-            <th>價格(元)</th>
-            <th>類型</th>
-            <th className={styles.operationCol}>操作</th>
+            <th className="stock-col">{lang === 'en' ? 'Stock Code/Name' : '股票代碼/名稱'}</th>
+            <th>{lang === 'en' ? 'Transaction Date' : '交易日期'}</th>
+            <th>{lang === 'en' ? 'Quantity (shares)' : '數量(股)'}</th>
+            <th>{lang === 'en' ? 'Price(NT$)' : '價格(元)'}</th>
+            <th>{lang === 'en' ? 'Type' : '類型'}</th>
+            <th className={styles.operationCol}>{lang === 'en' ? 'Actions' : '操作'}</th>
           </tr>
         </thead>
         <tbody>
           {transactionHistory.length === 0 ? (
-            <tr><td colSpan={6}>尚無交易紀錄</td></tr>
+            <tr><td colSpan={6}>{lang === 'en' ? 'No transaction records' : '尚無交易紀錄'}</td></tr>
           ) : (
             transactionHistory.map((item, idx) => {
               const stock = stockList.find(s => s.stock_id === item.stock_id) || {};
@@ -53,7 +55,7 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
                       />
                     ) : (
                       <>
-                        {item.quantity} ({(item.quantity / 1000).toFixed(3).replace(/\.0+$/, '')} 張)
+                        {item.quantity} ({(item.quantity / 1000).toFixed(3).replace(/\.0+$/, '')} {lang === 'en' ? 'lots' : '張'})
                       </>
                     )}
                   </td>
@@ -74,13 +76,13 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
                       '-'
                     )}
                   </td>
-                  <td>{item.type === 'sell' ? '賣出' : '買入'}</td>
+                  <td>{item.type === 'sell' ? (lang === 'en' ? 'Sell' : '賣出') : (lang === 'en' ? 'Buy' : '買入')}</td>
                   <td className={styles.operationCol}>
                     <div className={styles.actions}>
                       {isEditing ? (
                         <>
-                          <button onClick={() => handleEditSave(idx)}>儲存</button>
-                          <button onClick={() => setEditingIdx(null)} className={styles.actionButton}>取消</button>
+                          <button onClick={() => handleEditSave(idx)}>{lang === 'en' ? 'Save' : '儲存'}</button>
+                          <button onClick={() => setEditingIdx(null)} className={styles.actionButton}>{lang === 'en' ? 'Cancel' : '取消'}</button>
                         </>
                       ) : (
                         <>
@@ -90,13 +92,13 @@ export default function TransactionHistoryTable({ transactionHistory, stockList,
                               setEditForm({ date: item.date, quantity: item.quantity, price: item.price });
                             }}
                           >
-                            修改
+                            {lang === 'en' ? 'Edit' : '修改'}
                           </button>
                           <button
                             onClick={() => handleDelete(idx)}
                             className={styles.actionButton}
                           >
-                            刪除
+                            {lang === 'en' ? 'Delete' : '刪除'}
                           </button>
                         </>
                       )}


### PR DESCRIPTION
## Summary
- add LanguageContext support to transactional modals and dropdowns
- translate cookie consent banner and data menu actions
- localize transaction history table headers and actions

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c51880ce188329b8bae4460d410b7a