### PR TITLE
fix duplicate lang declaration in data dropdown

### DIFF
--- a/src/components/DataDropdown.jsx
+++ b/src/components/DataDropdown.jsx
@@ -24,7 +24,6 @@ export default function DataDropdown({
     action();
     onClose();
   };
-  const { lang } = useLanguage();
 
   const text = {
     zh: {
@@ -37,41 +36,43 @@ export default function DataDropdown({
     }
   };
 
+  const { importText, exportText } = text[lang];
+
   return (
     <div className={`action-dropdown silver-button-container ${styles.dataDropdown}`} ref={ref}>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>CSV</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleImportClick)}>{lang === 'en' ? 'Import' : '匯入'}</button>
-          <button onClick={() => handleAction(handleExportClick)}>{lang === 'en' ? 'Export' : '匯出'}</button>
+          <button onClick={() => handleAction(handleImportClick)}>{importText}</button>
+          <button onClick={() => handleAction(handleExportClick)}>{exportText}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>Google Drive</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleDriveImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
-          <button onClick={() => handleAction(handleDriveExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
+          <button onClick={() => handleAction(handleDriveImport)}>{importText}</button>
+          <button onClick={() => handleAction(handleDriveExport)}>{exportText}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>Dropbox</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleDropboxImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
-          <button onClick={() => handleAction(handleDropboxExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
+          <button onClick={() => handleAction(handleDropboxImport)}>{importText}</button>
+          <button onClick={() => handleAction(handleDropboxExport)}>{exportText}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>OneDrive</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleOneDriveImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
-          <button onClick={() => handleAction(handleOneDriveExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
+          <button onClick={() => handleAction(handleOneDriveImport)}>{importText}</button>
+          <button onClick={() => handleAction(handleOneDriveExport)}>{exportText}</button>
         </div>
       </div>
       <div className={styles.dataRow}>
         <span className={styles.dataLabel}>iCloudDrive</span>
         <div className={styles.buttonGroup}>
-          <button onClick={() => handleAction(handleOneDriveImport)}>{lang === 'en' ? 'Import' : '匯入'}</button>
-          <button onClick={() => handleAction(handleOneDriveExport)}>{lang === 'en' ? 'Export' : '匯出'}</button>
+          <button onClick={() => handleAction(handleICloudImport)}>{importText}</button>
+          <button onClick={() => handleAction(handleICloudExport)}>{exportText}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove duplicate language hook usage in DataDropdown
- centralize import/export text translations
- correct handler props for OneDrive and iCloud actions

## Testing
- `pnpm lint`
- `pnpm test` *(fails: InventoryTab.test.jsx due to act warning and missing button "新增購買紀錄")*

------
https://chatgpt.com/codex/tasks/task_e_68c58ac14c9c83299f21c58f9ea33e12