### PR TITLE
fix: remove unsupported stock list pagination

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -370,35 +370,16 @@ export default function InventoryTab() {
   useEffect(() => {
     const fetchAll = async () => {
       try {
-        const list = [];
-        let page = 1;
-        let cacheStatus = null;
-        let timestamp = null;
-
-        // fetch pages until no items are returned or we hit a safe upper bound
-        while (page <= 10) {
-          const { data, cacheStatus: cs, timestamp: ts } = await fetchWithCache(
-            `${API_HOST}/get_stock_list?page=${page}`
-          );
-
-          if (page === 1) {
-            cacheStatus = cs;
-            timestamp = ts;
-          }
-
-          const arr = Array.isArray(data)
-            ? data
-            : Array.isArray(data?.data)
-              ? data.data
-              : Array.isArray(data?.items)
-                ? data.items
-                : [];
-
-          if (arr.length === 0) break;
-          list.push(...arr);
-          page++;
-        }
-
+        const { data, cacheStatus, timestamp } = await fetchWithCache(
+          `${API_HOST}/get_stock_list`
+        );
+        const list = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.data)
+            ? data.data
+            : Array.isArray(data?.items)
+              ? data.items
+              : [];
         setStockList(list);
         setCacheInfo({ cacheStatus, timestamp });
       } catch {

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -15,10 +15,7 @@ describe('InventoryTab interactions', () => {
     Cookies.remove('my_transaction_history');
     fetchWithCache.mockImplementation((url) => {
       if (url.includes('/get_stock_list')) {
-        if (url.includes('page=1')) {
-          return Promise.resolve({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
-        }
-        return Promise.resolve({ data: [] });
+        return Promise.resolve({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
       }
       if (url.includes('/get_dividend')) {
         return Promise.resolve({ data: [{ stock_id: '0050', dividend_date: '2024-01-02', last_close_price: 20 }] });
@@ -29,7 +26,7 @@ describe('InventoryTab interactions', () => {
 
   test('opens add transaction modal', async () => {
     render(<InventoryTab />);
-    const openBtn = screen.getByRole('button', { name: '新增購買紀錄' });
+    const openBtn = await screen.findByRole('button', { name: '新增購買' });
     fireEvent.click(openBtn);
     await screen.findByRole('heading', { name: '新增購買紀錄' });
   });


### PR DESCRIPTION
## Summary
- stop sending unrecognized `page` query when fetching `/get_stock_list`
- adjust inventory tests for single-page stock list

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c58d039fe48329837d1d6e91bd6c96