### PR TITLE
Add language flag to site stats request

### DIFF
--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -5,11 +5,11 @@ import { useLanguage } from './i18n';
 
 export default function HomeTab() {
   const [stats, setStats] = useState({ milestones: [], latest: [], tip: '' });
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
 
   useEffect(() => {
     let cancelled = false;
-    fetchWithCache(`${API_HOST}/site_stats`, 4 * 60 * 60 * 1000)
+    fetchWithCache(`${API_HOST}/site_stats?en=${lang === 'en'}`, 4 * 60 * 60 * 1000)
       .then(({ data }) => {
         if (!cancelled) {
           setStats({
@@ -23,7 +23,7 @@ export default function HomeTab() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [lang]);
 
   return (
     <div className="container" style={{ maxWidth: 800 }}>

--- a/src/HomeTab.test.jsx
+++ b/src/HomeTab.test.jsx
@@ -62,3 +62,21 @@ test('renders knowledge section', async () => {
     )
   ).toBeInTheDocument();
 });
+
+test('fetches stats with en flag false for zh', async () => {
+  renderWithLang('zh');
+  await screen.findByText(translations.zh.site_stats);
+  expect(fetchWithCache).toHaveBeenCalledWith(
+    'http://localhost/site_stats?en=false',
+    expect.any(Number)
+  );
+});
+
+test('fetches stats with en flag true for en', async () => {
+  renderWithLang('en');
+  await screen.findByText(translations.en.site_stats);
+  expect(fetchWithCache).toHaveBeenCalledWith(
+    'http://localhost/site_stats?en=true',
+    expect.any(Number)
+  );
+});


### PR DESCRIPTION
## Summary
- include user language flag when requesting `/site_stats`
- test that `en` query parameter reflects selected language

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a83d3d408329b92b6682e34a2fdf