### PR TITLE
Limit dividend API to current and previous year

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,11 @@ import { getTomorrowDividendAlerts } from './dividendUtils';
 
 const DEFAULT_MONTHLY_GOAL = 10000;
 
+const CURRENT_YEAR = new Date().getFullYear();
+const PREVIOUS_YEAR = CURRENT_YEAR - 1;
+const DIVIDEND_YEAR_QUERY = `year=${CURRENT_YEAR}&year=${PREVIOUS_YEAR}`;
+const ALLOWED_YEARS = [CURRENT_YEAR, PREVIOUS_YEAR];
+
 const DEFAULT_WATCH_GROUPS = [
   {
     name: '現金流導向（月月配息）',
@@ -127,7 +132,7 @@ function App() {
   useEffect(() => {
     const callUpdate = () => {
       fetch(`${API_HOST}/update_dividend`).finally(() => {
-        clearCache(`${API_HOST}/get_dividend`);
+        clearCache(`${API_HOST}/get_dividend?${DIVIDEND_YEAR_QUERY}`);
         window.location.reload();
       });
     };
@@ -153,15 +158,16 @@ function App() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const { data: jsonData, cacheStatus, timestamp } = await fetchWithCache(`${API_HOST}/get_dividend`);
+        const { data: jsonData, cacheStatus, timestamp } = await fetchWithCache(`${API_HOST}/get_dividend?${DIVIDEND_YEAR_QUERY}`);
         const arr = Array.isArray(jsonData) ? jsonData : jsonData?.items;
         if (!Array.isArray(arr)) {
           throw new Error('Invalid data format');
         }
-        setData(arr);
+        const filteredArr = arr.filter(item => ALLOWED_YEARS.includes(new Date(item.dividend_date).getFullYear()));
+        setData(filteredArr);
         setDividendCacheInfo({ cacheStatus, timestamp });
 
-        const yearSet = new Set(arr.map(item => new Date(item.dividend_date).getFullYear()));
+        const yearSet = new Set(filteredArr.map(item => new Date(item.dividend_date).getFullYear()));
         const yearList = Array.from(yearSet).sort((a, b) => b - a);
         setYears(yearList);
         if (!yearSet.has(selectedYear)) setSelectedYear(yearList[0]);

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -17,6 +17,10 @@ import { useLanguage } from './i18n';
 
 const BACKUP_COOKIE_KEY = 'inventory_last_backup';
 
+const CURRENT_YEAR = new Date().getFullYear();
+const PREVIOUS_YEAR = CURRENT_YEAR - 1;
+const DIVIDEND_YEAR_QUERY = `year=${CURRENT_YEAR}&year=${PREVIOUS_YEAR}`;
+
 function getToday() {
   return new Date().toISOString().slice(0, 10);
 }
@@ -412,7 +416,7 @@ export default function InventoryTab() {
   }, [stockList]);
 
   useEffect(() => {
-    fetchWithCache(`${API_HOST}/get_dividend`)
+    fetchWithCache(`${API_HOST}/get_dividend?${DIVIDEND_YEAR_QUERY}`)
       .then(({ data }) => {
         const list = Array.isArray(data)
           ? data

--- a/src/StockDetail.jsx
+++ b/src/StockDetail.jsx
@@ -5,6 +5,11 @@ import './App.css';
 import Footer from './components/Footer';
 import { useLanguage } from './i18n';
 
+const CURRENT_YEAR = new Date().getFullYear();
+const PREVIOUS_YEAR = CURRENT_YEAR - 1;
+const DIVIDEND_YEAR_QUERY = `year=${CURRENT_YEAR}&year=${PREVIOUS_YEAR}`;
+const ALLOWED_YEARS = [CURRENT_YEAR, PREVIOUS_YEAR];
+
 export default function StockDetail({ stockId }) {
   const { lang } = useLanguage();
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark');
@@ -31,15 +36,16 @@ export default function StockDetail({ stockId }) {
   const { data: dividendList = [], isLoading: dividendLoading } = useQuery({
     queryKey: ['dividend'],
     queryFn: async () => {
-      const res = await fetch(`${API_HOST}/get_dividend`);
+      const res = await fetch(`${API_HOST}/get_dividend?${DIVIDEND_YEAR_QUERY}`);
       const data = await res.json();
-      return Array.isArray(data)
+      const arr = Array.isArray(data)
         ? data
         : Array.isArray(data?.data)
           ? data.data
           : Array.isArray(data?.items)
             ? data.items
             : [];
+      return arr.filter(item => ALLOWED_YEARS.includes(new Date(item.dividend_date).getFullYear()));
     },
     staleTime: 2 * 60 * 60 * 1000,
   });


### PR DESCRIPTION
## Summary
- Scope dividend data to the current and previous year only
- Pass year filters to all get_dividend API calls
- Ensure cache clearing and stock detail views respect the year-limited data

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c60db4fd3c8329b5460d65bc80e29c