### PR TITLE
Persist calendar visibility settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,7 +63,13 @@ function App() {
   const [upcomingAlerts, setUpcomingAlerts] = useState([]);
 
   // Toggle calendar visibility
-  const [showCalendar, setShowCalendar] = useState(true);
+  const [showCalendar, setShowCalendar] = useState(() => {
+    const stored = localStorage.getItem('appShowCalendar');
+    return stored === null ? true : stored === 'true';
+  });
+  useEffect(() => {
+    localStorage.setItem('appShowCalendar', showCalendar);
+  }, [showCalendar]);
 
   // Filter which event types to show on calendar
   // Default to displaying both ex-dividend and payment dates

--- a/src/AppCalendarVisibility.test.jsx
+++ b/src/AppCalendarVisibility.test.jsx
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import { render, screen, fireEvent } from '@testing-library/react';
+// Mock asset imports used by App
+jest.mock('./assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('./assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+
+jest.mock('./api', () => ({
+  fetchWithCache: jest.fn(() => Promise.resolve({ data: [], cacheStatus: 'fresh', timestamp: '' })),
+  clearCache: jest.fn(),
+}));
+
+jest.mock('./config', () => ({ API_HOST: '' }));
+
+import App from './App';
+
+beforeAll(() => {
+  globalThis.fetch = jest.fn(() => Promise.resolve({}));
+});
+
+test('App remembers calendar visibility', async () => {
+  localStorage.clear();
+  const { unmount } = render(<App />);
+  const dividendTab = screen.getByRole('button', { name: 'ETF 配息查詢' });
+  fireEvent.click(dividendTab);
+  const hideBtn = await screen.findByRole('button', { name: '隱藏月曆' });
+  fireEvent.click(hideBtn);
+  unmount();
+  render(<App />);
+  const dividendTab2 = screen.getByRole('button', { name: 'ETF 配息查詢' });
+  fireEvent.click(dividendTab2);
+  const showBtn = await screen.findByRole('button', { name: '顯示月曆' });
+  expect(showBtn).toBeInTheDocument();
+});

--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -20,7 +20,10 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
         ? ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
         : ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
     const [history, setHistory] = useState([]);
-    const [showCalendar, setShowCalendar] = useState(true);
+    const [showCalendar, setShowCalendar] = useState(() => {
+        const stored = localStorage.getItem('userDividendsShowCalendar');
+        return stored === null ? true : stored === 'true';
+    });
     // Default to showing both ex-dividend and payment events
     const [calendarFilter, setCalendarFilter] = useState('both');
     const timeZone = 'Asia/Taipei';
@@ -29,6 +32,10 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     useEffect(() => {
         setHistory(getTransactionHistory());
     }, []);
+
+    useEffect(() => {
+        localStorage.setItem('userDividendsShowCalendar', showCalendar);
+    }, [showCalendar]);
 
     function getHolding(stock_id, date) {
         return history.reduce((sum, item) => {

--- a/src/UserDividendsTabCalendarVisibility.test.jsx
+++ b/src/UserDividendsTabCalendarVisibility.test.jsx
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import { render, screen, fireEvent } from '@testing-library/react';
+import UserDividendsTab from './UserDividendsTab';
+import { readTransactionHistory } from './transactionStorage';
+
+jest.mock('./transactionStorage');
+jest.mock('./config', () => ({ API_HOST: '' }));
+
+test('UserDividendsTab remembers calendar visibility', async () => {
+  localStorage.clear();
+  readTransactionHistory.mockReturnValue([]);
+  const allDividendData = [];
+  const year = new Date().getFullYear();
+  const { unmount } = render(<UserDividendsTab allDividendData={allDividendData} selectedYear={year} />);
+  const hideBtn = await screen.findByRole('button', { name: '隱藏月曆' });
+  fireEvent.click(hideBtn);
+  unmount();
+  render(<UserDividendsTab allDividendData={allDividendData} selectedYear={year} />);
+  const showBtn = await screen.findByRole('button', { name: '顯示月曆' });
+  expect(showBtn).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- store calendar visibility in localStorage for main and user dividend pages
- add tests ensuring visibility preference persists across sessions

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ed0658a483298f46b985d75f7932