### PR TITLE
Improve dividend controls layout on small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -625,6 +625,34 @@ button:active {
   gap: 4px;
 }
 
+.group-create-button {
+  margin-left: 4px;
+}
+
+@media (max-width: 600px) {
+  .dividend-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-pair {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    white-space: normal;
+  }
+
+  .control-pair select {
+    width: 100%;
+  }
+
+  .group-create-button {
+    margin-left: 0;
+    margin-top: 4px;
+    align-self: flex-start;
+  }
+}
+
 .more-item {
   position: relative;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -617,7 +617,12 @@ function App() {
                   <option key={g.name} value={g.name}>{renderGroupOptionLabel(g)}</option>
                 ))}
               </select>
-              <button onClick={() => setShowGroupModal(true)} style={{ marginLeft: 4 }}>{lang === 'en' ? 'Create' : '建立'}</button>
+              <button
+                onClick={() => setShowGroupModal(true)}
+                className="group-create-button"
+              >
+                {lang === 'en' ? 'Create' : '建立'}
+              </button>
             </div>
           </div>
           <button


### PR DESCRIPTION
## Summary
- replace the inline style on the watch group create button with a reusable class
- add mobile responsive styles so the dividend controls stack vertically and keep the create button visible on narrow screens

## Testing
- pnpm test --passWithNoTests --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cb782242648329bbf2142e69d975d7