### PR TITLE
Preserve horizontal scroll position across dividend tables

### DIFF
--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import DividendCalendar from './components/DividendCalendar';
 import { readTransactionHistory } from './transactionStorage';
 import { HOST_URL } from './config';
 import { useLanguage } from './i18n';
+import usePreserveScroll from './hooks/usePreserveScroll';
 
 const MONTH_COL_WIDTH = 80;
 function getTransactionHistory() {
@@ -30,6 +31,8 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const currentMonth = Number(new Date().toLocaleString('en-US', { timeZone, month: 'numeric' })) - 1;
     const [sortConfig, setSortConfig] = useState({ column: 'stock_id', direction: 'asc' });
     const [monthFilters, setMonthFilters] = useState(() => Array(12).fill(false));
+    const tableContainerRef = useRef(null);
+    usePreserveScroll(tableContainerRef, 'userDividendsTableScroll');
     useEffect(() => {
         setHistory(getTransactionHistory());
     }, []);
@@ -317,7 +320,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                 </button>
             </div>
 
-            <div className="table-responsive">
+            <div className="table-responsive" ref={tableContainerRef}>
             <table className="table table-bordered table-striped">
                 <thead>
                     <tr>

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 // Removed react-window virtualization to avoid invalid table markup
 import FilterDropdown from './FilterDropdown';
 import AdvancedFilterDropdown from './AdvancedFilterDropdown';
 import { HOST_URL } from '../config';
 import { useLanguage } from '../i18n';
+import usePreserveScroll from '../hooks/usePreserveScroll';
 
 const NUM_COL_WIDTH = 80;
 
@@ -37,6 +38,7 @@ export default function StockTable({
   const [sortConfig, setSortConfig] = useState({ column: 'stock_id', direction: 'asc' });
   const [showIdDropdown, setShowIdDropdown] = useState(false);
   const [showExtraDropdown, setShowExtraDropdown] = useState(false);
+  const tableContainerRef = useRef(null);
   const { lang, t } = useLanguage();
   const MONTHS = lang === 'zh'
     ? ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
@@ -44,6 +46,8 @@ export default function StockTable({
   const freqNameMap = lang === 'zh'
     ? { 1: '年配', 2: '半年配', 4: '季配', 6: '雙月配', 12: '月配' }
     : { 1: 'Annual', 2: 'Semi-annual', 4: 'Quarterly', 6: 'Bimonthly', 12: 'Monthly' };
+
+  usePreserveScroll(tableContainerRef, 'stockTableScrollLeft', [showInfoAxis]);
 
   const handleSort = (column) => {
     setSortConfig(prev => {
@@ -161,7 +165,7 @@ export default function StockTable({
 
   if (showInfoAxis) {
     return (
-      <div className="table-responsive">
+      <div className="table-responsive" ref={tableContainerRef}>
         <table className="table table-bordered table-striped">
           <thead>
             <tr>
@@ -221,7 +225,7 @@ export default function StockTable({
   }
 
   return (
-    <div className="table-responsive">
+    <div className="table-responsive" ref={tableContainerRef}>
       <table className="table table-bordered table-striped" style={{ minWidth: 1380 }}>
         <thead>
           <tr>

--- a/src/hooks/usePreserveScroll.js
+++ b/src/hooks/usePreserveScroll.js
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+export default function usePreserveScroll(ref, storageKey, deps = []) {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof sessionStorage === 'undefined') {
+      return;
+    }
+
+    const saved = sessionStorage.getItem(storageKey);
+    if (saved !== null) {
+      const savedValue = Number(saved);
+      if (!Number.isNaN(savedValue)) {
+        node.scrollLeft = savedValue;
+      }
+    }
+
+    const handleScroll = () => {
+      sessionStorage.setItem(storageKey, String(node.scrollLeft));
+    };
+
+    node.addEventListener('scroll', handleScroll);
+
+    return () => {
+      sessionStorage.setItem(storageKey, String(node.scrollLeft));
+      node.removeEventListener('scroll', handleScroll);
+    };
+  }, [ref, storageKey, ...deps]);
+}


### PR DESCRIPTION
## Summary
- add a reusable hook to persist horizontal scroll positions for tables
- apply the hook to the monthly dividend and user dividend overview tables so tabs remember their scroll state

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8915942c83299fbad7d395e16f16