### PR TITLE
Improve advanced filter layout for mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -160,6 +160,101 @@ td {
   color: var(--color-text);
 }
 
+.advanced-dropdown {
+  padding: 16px 18px 12px 18px;
+  width: min(320px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.advanced-dropdown__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.advanced-dropdown__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent-gold);
+  line-height: 1.3;
+}
+
+.advanced-dropdown__input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.advanced-dropdown__input {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-bg);
+  color: var(--color-text);
+}
+
+.advanced-dropdown__input:focus {
+  outline: 2px solid var(--accent-gold);
+  outline-offset: 1px;
+}
+
+.advanced-dropdown__suffix {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.advanced-dropdown__freq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 6px 10px;
+  max-height: 150px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.advanced-dropdown__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  padding: 4px 0;
+}
+
+.advanced-dropdown__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+@media (max-width: 480px) {
+  .advanced-dropdown {
+    padding: 18px 20px 14px;
+    width: min(360px, calc(100vw - 24px));
+    gap: 12px;
+  }
+
+  .advanced-dropdown__label {
+    font-size: 14px;
+  }
+
+  .advanced-dropdown__input,
+  .advanced-dropdown__suffix,
+  .advanced-dropdown__checkbox {
+    font-size: 14px;
+  }
+
+  .advanced-dropdown__freq-grid {
+    gap: 8px 12px;
+  }
+}
+
 .dropdown label {
   display: flex;
   align-items: center;

--- a/src/components/AdvancedFilterDropdown.jsx
+++ b/src/components/AdvancedFilterDropdown.jsx
@@ -25,58 +25,72 @@ export default function AdvancedFilterDropdown({ filters, setFilters, onClose })
     onClose();
   };
 
+  const freqOptions = [
+    { v: 12, zh: '月配', en: 'Monthly' },
+    { v: 6, zh: '雙月配', en: 'Bimonthly' },
+    { v: 4, zh: '季配', en: 'Quarterly' },
+    { v: 2, zh: '半年配', en: 'Semi-annual' },
+    { v: 1, zh: '年配', en: 'Annual' }
+  ];
+
   return (
-    <div className="dropdown" ref={ref} style={{ padding: 8, zIndex: 9999 }}>
-      <div className="dropdown-section">
-        <label>
-          {lang === 'en' ? 'Estimated yield ≥' : '預估殖利率 ≥'}
+    <div className="dropdown advanced-dropdown" ref={ref}>
+      <div className="dropdown-section advanced-dropdown__section">
+        <span className="advanced-dropdown__label">{lang === 'en' ? 'Estimated yield ≥' : '預估殖利率 ≥'}</span>
+        <div className="advanced-dropdown__input-row">
           <input
             type="number"
             value={temp.minYield}
             onChange={e => setTemp({ ...temp, minYield: e.target.value })}
-            style={{ width: 60, marginLeft: 4 }}
-          />%
-        </label>
+            className="advanced-dropdown__input"
+          />
+          <span className="advanced-dropdown__suffix">%</span>
+        </div>
       </div>
       <hr />
-      <div className="dropdown-section" style={{ maxHeight: 100, overflowY: 'auto' }}>
-        {[{ v: 12, zh: '月配', en: 'Monthly' }, { v: 6, zh: '雙月配', en: 'Bimonthly' }, { v: 4, zh: '季配', en: 'Quarterly' }, { v: 2, zh: '半年配', en: 'Semi-annual' }, { v: 1, zh: '年配', en: 'Annual' }].map(opt => (
-          <label key={opt.v} className="dropdown-item">
-            <input
-              type="checkbox"
-              checked={temp.freq.includes(opt.v)}
-              onChange={() => toggleFreq(opt.v)}
-            /> {lang === 'en' ? opt.en : opt.zh}
-          </label>
-        ))}
+      <div className="dropdown-section advanced-dropdown__section">
+        <span className="advanced-dropdown__label">{lang === 'en' ? 'Payout frequency' : '配息頻率'}</span>
+        <div className="advanced-dropdown__freq-grid">
+          {freqOptions.map(opt => (
+            <label key={opt.v} className="dropdown-item advanced-dropdown__checkbox">
+              <input
+                type="checkbox"
+                checked={temp.freq.includes(opt.v)}
+                onChange={() => toggleFreq(opt.v)}
+              />
+              <span>{lang === 'en' ? opt.en : opt.zh}</span>
+            </label>
+          ))}
+        </div>
       </div>
       <hr />
-      <div className="dropdown-section">
-        <label className="dropdown-item">
+      <div className="dropdown-section advanced-dropdown__section">
+        <label className="dropdown-item advanced-dropdown__checkbox">
           <input
             type="checkbox"
             checked={temp.diamond}
             onChange={e => setTemp({ ...temp, diamond: e.target.checked })}
-          /> {lang === 'en' ? 'Show only diamonds' : '只顯示鑽石'}
+          />
+          <span>{lang === 'en' ? 'Show only diamonds' : '只顯示鑽石'}</span>
         </label>
       </div>
       <hr />
-      <div className="dropdown-section">
-        <label>
-          {lang === 'en' ? 'Upcoming ex/payout within' : '即將除息/發息：未來'}
+      <div className="dropdown-section advanced-dropdown__section">
+        <span className="advanced-dropdown__label">{lang === 'en' ? 'Upcoming ex/payout within' : '即將除息/發息：未來'}</span>
+        <div className="advanced-dropdown__input-row">
           <input
             type="number"
             value={temp.upcomingWithin}
             onChange={e => setTemp({ ...temp, upcomingWithin: e.target.value })}
-            style={{ width: 60, margin: '0 4px' }}
-          />{lang === 'en' ? 'days' : '天內'}
-        </label>
+            className="advanced-dropdown__input"
+          />
+          <span className="advanced-dropdown__suffix">{lang === 'en' ? 'days' : '天內'}</span>
+        </div>
       </div>
-      <div style={{ marginTop: 8, textAlign: 'right' }}>
+      <div className="advanced-dropdown__actions">
         <button className="dropdown-btn" onClick={handleClear}>{lang === 'en' ? 'Clear' : '清除'}</button>
-        <button className="dropdown-btn" style={{ marginLeft: 8 }} onClick={handleApply}>{lang === 'en' ? 'Apply' : '確定'}</button>
+        <button className="dropdown-btn" onClick={handleApply}>{lang === 'en' ? 'Apply' : '確定'}</button>
       </div>
     </div>
   );
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
   --color-row-even: #f3f4f6;
   --color-hover: #e5e7eb;
   --color-header-bg: #f3f4f6;
+  --color-text-muted: #6b7280;
   --accent-gold: #d4af37;
   --accent-gold-hover: #ffd700;
   --accent-green: #2f9e44;
@@ -47,6 +48,7 @@
   --color-row-even: #1f2937;
   --color-hover: #374151;
   --color-header-bg: #374151;
+  --color-text-muted: #9ca3af;
 }
 
 [data-theme='dark'] .nav-tabs .nav-link.active {


### PR DESCRIPTION
## Summary
- refactor the advanced filter dropdown markup to space controls vertically and add clearer labels
- add responsive styling so the dropdown uses the viewport width on phones and introduces a grid for frequency chips
- define a muted text color token for light/dark themes and reuse it in the dropdown helper text

## Testing
- pnpm lint *(fails: existing eslint warnings in InventoryTab.jsx/usePreserveScroll.js and no-undef errors in googleDrive tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8b3382388329adfa2892ab55a44f