### PR TITLE
Refine goal card visibility and targeting

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -52,6 +52,7 @@ export default function InventoryTab() {
     monthlyTarget: initialGoals.monthlyTarget ? String(initialGoals.monthlyTarget) : ''
   }));
   const [goalSaved, setGoalSaved] = useState(false);
+  const [isGoalFormVisible, setIsGoalFormVisible] = useState(false);
   const text = {
     zh: {
       importOverwrite: '匯入後將覆蓋現有紀錄，是否繼續？',
@@ -103,6 +104,8 @@ export default function InventoryTab() {
       goalEmpty: '還沒設定股息計畫？給目標取個響亮的名字，再填上年度與每月數字吧！',
       goalInputPlaceholderTotal: '例：50000',
       goalInputPlaceholderMonthly: '例：5000',
+      goalFormShow: '設定或更新目標',
+      goalFormHide: '收起設定',
       goalAnnualHalf: '年度進度過半，離夢想更近一步！',
       goalAnnualDone: '恭喜完成年度目標，繼續打造現金流！',
       goalMonthlyHalf: '這個月過半囉，再衝一把！',
@@ -170,6 +173,8 @@ export default function InventoryTab() {
       goalEmpty: 'No plan yet—give your dividend goal a name and add annual and monthly targets below to stay focused.',
       goalInputPlaceholderTotal: 'e.g. 5000',
       goalInputPlaceholderMonthly: 'e.g. 500',
+      goalFormShow: 'Add or edit goal',
+      goalFormHide: 'Hide goal form',
       goalAnnualHalf: 'Halfway through the year—your dream cashflow is getting closer!',
       goalAnnualDone: 'Annual goal achieved! Keep that momentum building income!',
       goalMonthlyHalf: 'Over halfway this month—one more push!',
@@ -517,6 +522,10 @@ export default function InventoryTab() {
   const goalSavedMessage = goalSaved ? msg.goalSaved : '';
   const goalTitle = goals.goalName?.trim() ? goals.goalName.trim() : msg.investmentGoals;
 
+  const handleGoalFormToggle = () => {
+    setIsGoalFormVisible(prev => !prev);
+  };
+
   const handleGoalNameChange = event => {
     const value = event.target.value;
     setGoalForm(prev => ({ ...prev, name: value }));
@@ -723,6 +732,13 @@ export default function InventoryTab() {
               savedMessage={goalSavedMessage}
               emptyState={goalEmptyState}
               form={{
+                id: 'inventory-goal-form',
+                isVisible: isGoalFormVisible,
+                toggle: {
+                  label: isGoalFormVisible ? msg.goalFormHide : msg.goalFormShow,
+                  onClick: handleGoalFormToggle,
+                  ariaControls: 'inventory-goal-form'
+                },
                 onSubmit: handleGoalSubmit,
                 intro: msg.goalFormIntro,
                 nameId: 'inventory-goal-name',

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -35,6 +35,9 @@ describe('InventoryTab interactions', () => {
     render(<InventoryTab />);
     expect(await screen.findByText('預期的股息目標')).toBeInTheDocument();
     expect(screen.getByText('累積股息')).toBeInTheDocument();
+    expect(screen.queryByLabelText('幫目標取個名字')).not.toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: '設定或更新目標' });
+    fireEvent.click(toggle);
     expect(screen.getByLabelText('幫目標取個名字')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('例：50000')).toBeInTheDocument();
   });

--- a/src/components/InvestmentGoalCard.jsx
+++ b/src/components/InvestmentGoalCard.jsx
@@ -1,6 +1,9 @@
 import styles from './InvestmentGoalCard.module.css';
 
 export default function InvestmentGoalCard({ title, metrics = [], rows, savedMessage, form, emptyState }) {
+  const { isVisible: formIsVisible = true, toggle: formToggle, id: formId, ...formProps } = form || {};
+  const shouldRenderForm = Boolean(form) && formIsVisible !== false;
+
   return (
     <section className={styles.card}>
       <div className={styles.header}>
@@ -46,50 +49,61 @@ export default function InvestmentGoalCard({ title, metrics = [], rows, savedMes
           </div>
         ))}
         {emptyState ? <div className={styles.emptyState}>{emptyState}</div> : null}
-        {form ? (
-          <form className={styles.form} onSubmit={form.onSubmit}>
-            {form.intro ? <p className={styles.formIntro}>{form.intro}</p> : null}
-            {form.nameLabel ? (
+        {formToggle ? (
+          <button
+            type="button"
+            className={styles.formToggleButton}
+            onClick={formToggle.onClick}
+            aria-expanded={shouldRenderForm}
+            aria-controls={formToggle.ariaControls || formId || undefined}
+          >
+            {formToggle.label}
+          </button>
+        ) : null}
+        {shouldRenderForm ? (
+          <form id={formId} className={styles.form} onSubmit={formProps.onSubmit}>
+            {formProps.intro ? <p className={styles.formIntro}>{formProps.intro}</p> : null}
+            {formProps.nameLabel ? (
               <div className={styles.inputGroup}>
-                <label htmlFor={form.nameId}>{form.nameLabel}</label>
+                <label htmlFor={formProps.nameId}>{formProps.nameLabel}</label>
                 <input
-                  id={form.nameId}
+                  id={formProps.nameId}
                   type="text"
-                  value={form.nameValue}
-                  onChange={form.onNameChange}
-                  placeholder={form.namePlaceholder}
-                  maxLength={form.nameMaxLength || 60}
+                  value={formProps.nameValue}
+                  onChange={formProps.onNameChange}
+                  placeholder={formProps.namePlaceholder}
+                  maxLength={formProps.nameMaxLength || 60}
                 />
-                {form.nameHelper ? <span className={styles.inputHelper}>{form.nameHelper}</span> : null}
+                {formProps.nameHelper ? <span className={styles.inputHelper}>{formProps.nameHelper}</span> : null}
               </div>
             ) : null}
             <div className={styles.inputGroup}>
-              <label htmlFor={form.totalId}>{form.totalLabel}</label>
+              <label htmlFor={formProps.totalId}>{formProps.totalLabel}</label>
               <input
-                id={form.totalId}
+                id={formProps.totalId}
                 type="number"
                 inputMode="decimal"
-                value={form.totalValue}
-                onChange={form.onTotalChange}
-                placeholder={form.totalPlaceholder}
+                value={formProps.totalValue}
+                onChange={formProps.onTotalChange}
+                placeholder={formProps.totalPlaceholder}
                 min="0"
                 step="1000"
               />
             </div>
             <div className={styles.inputGroup}>
-              <label htmlFor={form.monthlyId}>{form.monthlyLabel}</label>
+              <label htmlFor={formProps.monthlyId}>{formProps.monthlyLabel}</label>
               <input
-                id={form.monthlyId}
+                id={formProps.monthlyId}
                 type="number"
                 inputMode="decimal"
-                value={form.monthlyValue}
-                onChange={form.onMonthlyChange}
-                placeholder={form.monthlyPlaceholder}
+                value={formProps.monthlyValue}
+                onChange={formProps.onMonthlyChange}
+                placeholder={formProps.monthlyPlaceholder}
                 min="0"
                 step="100"
               />
             </div>
-            <button type="submit">{form.saveLabel}</button>
+            <button type="submit">{formProps.saveLabel}</button>
           </form>
         ) : null}
       </div>

--- a/src/components/InvestmentGoalCard.module.css
+++ b/src/components/InvestmentGoalCard.module.css
@@ -29,6 +29,23 @@
   gap: 16px;
 }
 
+.formToggleButton {
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.3));
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.formToggleButton:hover,
+.formToggleButton:focus-visible {
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));

--- a/src/dividendGoalUtils.js
+++ b/src/dividendGoalUtils.js
@@ -131,44 +131,41 @@ export function buildDividendGoalViewModel({ summary = {}, goals = {}, messages 
     }
   ].filter(metric => Boolean(metric.label));
 
-  const rows = [
-    {
+  const rows = [];
+
+  if (annualGoalSet) {
+    rows.push({
       id: 'annual',
       label: messages.annualGoal,
       current: `${messages.goalDividendAccumulated}${formatCurrency(yearToDateTotal)}`,
-      target: `${messages.goalTargetAnnual}${annualGoalSet ? formatCurrency(annualGoal) : placeholder}`,
+      target: `${messages.goalTargetAnnual}${formatCurrency(annualGoal)}`,
       percent: annualPercentValue,
-      percentLabel: annualGoalSet
-        ? `${Math.min(100, Math.round(annualPercentValue * 100))}%`
-        : placeholder,
-      encouragement: annualGoalSet
-        ? annualPercentValue >= 1
-          ? messages.goalAnnualDone
-          : annualPercentValue >= 0.5
-            ? messages.goalAnnualHalf
-            : ''
-        : ''
-    },
-    {
+      percentLabel: `${Math.min(100, Math.round(annualPercentValue * 100))}%`,
+      encouragement: annualPercentValue >= 1
+        ? messages.goalAnnualDone
+        : annualPercentValue >= 0.5
+          ? messages.goalAnnualHalf
+          : ''
+    });
+  }
+
+  if (monthlyGoalSet) {
+    rows.push({
       id: 'monthly',
       label: messages.monthlyGoal,
       current: `${messages.goalDividendMonthly}${formatCurrency(monthlyAverage)}`,
-      target: `${messages.goalTargetMonthly}${monthlyGoalSet ? formatCurrency(monthlyGoal) : placeholder}`,
+      target: `${messages.goalTargetMonthly}${formatCurrency(monthlyGoal)}`,
       percent: monthlyPercentValue,
-      percentLabel: monthlyGoalSet
-        ? `${Math.min(100, Math.round(monthlyPercentValue * 100))}%`
-        : placeholder,
-      encouragement: monthlyGoalSet
-        ? monthlyPercentValue >= 1
-          ? messages.goalMonthlyDone
-          : monthlyPercentValue >= 0.5
-            ? messages.goalMonthlyHalf
-            : ''
-        : ''
-    }
-  ];
+      percentLabel: `${Math.min(100, Math.round(monthlyPercentValue * 100))}%`,
+      encouragement: monthlyPercentValue >= 1
+        ? messages.goalMonthlyDone
+        : monthlyPercentValue >= 0.5
+          ? messages.goalMonthlyHalf
+          : ''
+    });
+  }
 
-  const emptyState = !annualGoalSet && !monthlyGoalSet ? messages.goalEmpty || '' : '';
+  const emptyState = rows.length === 0 ? messages.goalEmpty || '' : '';
 
   return {
     metrics,

--- a/src/dividendGoalUtils.test.js
+++ b/src/dividendGoalUtils.test.js
@@ -83,4 +83,89 @@ describe('dividend goal helpers', () => {
       encouragement: '月過半'
     });
   });
+
+  test('omits goal rows when targets are not provided', () => {
+    const summary = {
+      yearToDateTotal: 900,
+      annualTotal: 1500,
+      annualYear: 2023,
+      monthlyAverage: 120
+    };
+    const messages = {
+      annualGoal: '年度目標',
+      monthlyGoal: '每月目標',
+      goalDividendAccumulated: '累積股息：',
+      goalDividendMonthly: '每月股息：',
+      goalDividendYtdLabel: '累積股息',
+      goalDividendAnnualLabel: '年度股息',
+      goalDividendMonthlyLabel: '每月股息',
+      goalAchievementLabel: '達成率',
+      goalTargetAnnual: '年度目標：',
+      goalTargetMonthly: '每月目標：',
+      goalPercentPlaceholder: '--',
+      goalAnnualHalf: '年度過半',
+      goalAnnualDone: '年度完成',
+      goalMonthlyHalf: '月過半',
+      goalMonthlyDone: '月完成',
+      goalEmpty: '請新增目標'
+    };
+
+    const { rows, emptyState } = buildDividendGoalViewModel({
+      summary,
+      goals: { totalTarget: 0, monthlyTarget: 300 },
+      messages,
+      formatCurrency: value => Number(value).toFixed(0)
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: 'monthly' });
+    expect(emptyState).toBe('');
+
+    const noGoals = buildDividendGoalViewModel({
+      summary,
+      goals: { totalTarget: 0, monthlyTarget: 0 },
+      messages,
+      formatCurrency: value => Number(value).toFixed(0)
+    });
+
+    expect(noGoals.rows).toHaveLength(0);
+    expect(noGoals.emptyState).toBe('請新增目標');
+  });
+
+  test('uses current year dividends when calculating achievement', () => {
+    const summary = {
+      yearToDateTotal: 900,
+      annualTotal: 1800,
+      annualYear: 2023,
+      monthlyAverage: 150
+    };
+    const messages = {
+      annualGoal: '年度目標',
+      monthlyGoal: '每月目標',
+      goalDividendAccumulated: '累積股息：',
+      goalDividendMonthly: '每月股息：',
+      goalDividendYtdLabel: '累積股息',
+      goalDividendAnnualLabel: '年度股息',
+      goalDividendMonthlyLabel: '每月股息',
+      goalAchievementLabel: '達成率',
+      goalTargetAnnual: '年度目標：',
+      goalTargetMonthly: '每月目標：',
+      goalPercentPlaceholder: '--',
+      goalAnnualHalf: '年度過半',
+      goalAnnualDone: '年度完成',
+      goalMonthlyHalf: '月過半',
+      goalMonthlyDone: '月完成',
+      goalEmpty: ''
+    };
+
+    const { metrics } = buildDividendGoalViewModel({
+      summary,
+      goals: { totalTarget: 1800, monthlyTarget: 0 },
+      messages,
+      formatCurrency: value => Number(value).toFixed(0)
+    });
+
+    const achievementMetric = metrics.find(metric => metric.id === 'achievement');
+    expect(achievementMetric.value).toBe('50%');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure the dividend goal view only shows annual/monthly targets when present and keeps achievement tied to current-year progress
- add a toggle button and styles so the inventory goal form stays hidden until requested while preserving saved messaging
- expand tests for the goal view model and inventory tab to cover the new behaviors

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cbfa9189288329a3d7741d13542689