### PR TITLE
Adjust dividend data fetches to use year-specific requests

### DIFF
--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { API_HOST } from './config';
 import { fetchWithCache } from './api';
+import { fetchDividendsByYears } from './dividendApi';
 import { useLanguage } from './i18n';
 import { readTransactionHistory } from './transactionStorage';
 import { summarizeInventory } from './inventoryUtils';
 import { loadInvestmentGoals } from './investmentGoalsStorage';
 import InvestmentGoalCard from './components/InvestmentGoalCard';
 import {
-  DIVIDEND_YEAR_QUERY,
-  normalizeDividendResponse,
   calculateDividendSummary,
   buildDividendGoalViewModel
 } from './dividendGoalUtils';
@@ -52,10 +51,10 @@ export default function HomeTab() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchWithCache(`${API_HOST}/get_dividend?${DIVIDEND_YEAR_QUERY}`)
+    fetchDividendsByYears()
       .then(({ data }) => {
         if (!cancelled) {
-          setDividendData(normalizeDividendResponse(data));
+          setDividendData(data);
         }
       })
       .catch(() => {

--- a/src/HomeTab.test.jsx
+++ b/src/HomeTab.test.jsx
@@ -26,13 +26,19 @@ const mockDividendData = [
   { stock_id: '0050', dividend_date: '2024-01-10', dividend: 1, last_close_price: 20 }
 ];
 
+const currentYear = new Date().getFullYear();
+const previousYear = currentYear - 1;
+
 beforeEach(() => {
   localStorage.clear();
   fetchWithCache.mockImplementation((url) => {
     if (url.includes('/site_stats')) {
       return Promise.resolve({ data: mockData });
     }
-    if (url.includes('/get_dividend')) {
+    if (url.includes(`/get_dividend?year=${currentYear}`)) {
+      return Promise.resolve({ data: mockDividendData });
+    }
+    if (url.includes(`/get_dividend?year=${previousYear}`)) {
       return Promise.resolve({ data: mockDividendData });
     }
     return Promise.resolve({ data: [] });

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import Cookies from 'js-cookie';
 import { API_HOST, HOST_URL } from './config';
 import { fetchWithCache } from './api';
+import { fetchDividendsByYears } from './dividendApi';
 import { migrateTransactionHistory, saveTransactionHistory } from './transactionStorage';
 import { exportTransactionsToDrive, importTransactionsFromDrive } from './googleDrive';
 import { exportTransactionsToOneDrive, importTransactionsFromOneDrive } from './oneDrive';
@@ -17,8 +18,6 @@ import InvestmentGoalCard from './components/InvestmentGoalCard';
 import { summarizeInventory } from './inventoryUtils';
 import { loadInvestmentGoals, saveInvestmentGoals } from './investmentGoalsStorage';
 import {
-  DIVIDEND_YEAR_QUERY,
-  normalizeDividendResponse,
   calculateDividendSummary,
   buildDividendGoalViewModel
 } from './dividendGoalUtils';
@@ -433,9 +432,9 @@ export default function InventoryTab() {
   }, [stockList]);
 
   useEffect(() => {
-    fetchWithCache(`${API_HOST}/get_dividend?${DIVIDEND_YEAR_QUERY}`)
+    fetchDividendsByYears()
       .then(({ data }) => {
-        const list = normalizeDividendResponse(data);
+        const list = data;
         setDividendData(list);
         const priceMap = {};
         list.forEach(item => {

--- a/src/InventoryTab.test.jsx
+++ b/src/InventoryTab.test.jsx
@@ -10,6 +10,9 @@ jest.mock('./config', () => ({
 }));
 
 describe('InventoryTab interactions', () => {
+  const currentYear = new Date().getFullYear();
+  const previousYear = currentYear - 1;
+
   beforeEach(() => {
     localStorage.clear();
     Cookies.remove('my_transaction_history');
@@ -17,7 +20,10 @@ describe('InventoryTab interactions', () => {
       if (url.includes('/get_stock_list')) {
         return Promise.resolve({ data: [{ stock_id: '0050', stock_name: 'Test ETF', dividend_frequency: 1 }] });
       }
-      if (url.includes('/get_dividend')) {
+      if (url.includes(`/get_dividend?year=${currentYear}`)) {
+        return Promise.resolve({ data: [{ stock_id: '0050', dividend_date: '2024-01-02', last_close_price: 20 }] });
+      }
+      if (url.includes(`/get_dividend?year=${previousYear}`)) {
         return Promise.resolve({ data: [{ stock_id: '0050', dividend_date: '2024-01-02', last_close_price: 20 }] });
       }
       return Promise.resolve({ data: [] });

--- a/src/StockDetail.test.jsx
+++ b/src/StockDetail.test.jsx
@@ -8,13 +8,15 @@ jest.mock('./config', () => ({
 }));
 
 beforeEach(() => {
+  const currentYear = new Date().getFullYear();
+  const previousYear = currentYear - 1;
   globalThis.fetch = jest.fn((url) => {
     if (url.includes('/get_stock_list')) {
       return Promise.resolve({
         json: () => Promise.resolve([{ stock_id: '0056', stock_name: 'Test ETF' }])
       });
     }
-    if (url.includes('/get_dividend')) {
+    if (url.includes(`/get_dividend?year=${currentYear}`) || url.includes(`/get_dividend?year=${previousYear}`)) {
       return Promise.resolve({
         json: () => Promise.resolve([])
       });

--- a/src/dividendApi.js
+++ b/src/dividendApi.js
@@ -1,0 +1,41 @@
+import { API_HOST } from './config';
+import { fetchWithCache, clearCache } from './api';
+import { normalizeDividendResponse, DIVIDEND_YEARS } from './dividendGoalUtils';
+
+function buildDividendUrl(year) {
+  return `${API_HOST}/get_dividend?year=${year}`;
+}
+
+export async function fetchDividendsByYears(years = DIVIDEND_YEARS) {
+  const requests = years.map(year => fetchWithCache(buildDividendUrl(year)));
+  const results = await Promise.allSettled(requests);
+
+  const fulfilled = results
+    .map((result, index) => (result.status === 'fulfilled'
+      ? { year: years[index], ...result.value }
+      : null))
+    .filter(Boolean);
+
+  if (!fulfilled.length) {
+    const firstRejection = results.find(result => result.status === 'rejected');
+    if (firstRejection?.reason) throw firstRejection.reason;
+    throw new Error('Failed to fetch dividend data');
+  }
+
+  const data = fulfilled.flatMap(({ data }) => normalizeDividendResponse(data));
+  const meta = fulfilled.map(({ year, cacheStatus, timestamp }) => ({
+    year,
+    cacheStatus: cacheStatus || null,
+    timestamp: timestamp || null
+  }));
+
+  return { data, meta };
+}
+
+export function clearDividendsCache(years = DIVIDEND_YEARS) {
+  years.forEach(year => {
+    clearCache(buildDividendUrl(year));
+  });
+}
+
+export { buildDividendUrl as buildDividendRequestUrl };

--- a/src/dividendGoalUtils.js
+++ b/src/dividendGoalUtils.js
@@ -1,7 +1,7 @@
-const CURRENT_YEAR = new Date().getFullYear();
-const PREVIOUS_YEAR = CURRENT_YEAR - 1;
+export const CURRENT_YEAR = new Date().getFullYear();
+export const PREVIOUS_YEAR = CURRENT_YEAR - 1;
 
-export const DIVIDEND_YEAR_QUERY = `year=${CURRENT_YEAR}&year=${PREVIOUS_YEAR}`;
+export const DIVIDEND_YEARS = [CURRENT_YEAR, PREVIOUS_YEAR];
 
 export function normalizeDividendResponse(payload) {
   if (Array.isArray(payload)) return payload;


### PR DESCRIPTION
## Summary
- update dividend data fetching to request one year per call and aggregate responses across views
- add a shared helper for clearing/fetching dividend data and update cache handling
- align StockDetail and tests with the new year-specific API requirement

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc20671dac8329a5807804d977006e