### PR TITLE
Fix dividend summary calculations using transaction history

### DIFF
--- a/src/HomeTab.jsx
+++ b/src/HomeTab.jsx
@@ -21,6 +21,7 @@ export default function HomeTab() {
       inventoryList: []
     };
   });
+  const [transactionHistory, setTransactionHistory] = useState([]);
   const [dividendData, setDividendData] = useState([]);
   const { t, lang } = useLanguage();
 
@@ -44,6 +45,7 @@ export default function HomeTab() {
 
   useEffect(() => {
     const history = readTransactionHistory();
+    setTransactionHistory(history);
     const { inventoryList } = summarizeInventory(history);
     const goals = loadInvestmentGoals();
     setGoalSummary({ goals, inventoryList });
@@ -78,9 +80,10 @@ export default function HomeTab() {
   const dividendSummary = useMemo(
     () => calculateDividendSummary({
       inventoryList: goalSummary.inventoryList,
-      dividendEvents: dividendData
+      dividendEvents: dividendData,
+      transactionHistory
     }),
-    [goalSummary.inventoryList, dividendData]
+    [goalSummary.inventoryList, dividendData, transactionHistory]
   );
 
   const goalMessages = useMemo(() => ({

--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -481,8 +481,12 @@ export default function InventoryTab() {
   }, []);
 
   const dividendSummary = useMemo(
-    () => calculateDividendSummary({ inventoryList, dividendEvents: dividendData }),
-    [inventoryList, dividendData]
+    () => calculateDividendSummary({
+      inventoryList,
+      dividendEvents: dividendData,
+      transactionHistory
+    }),
+    [inventoryList, dividendData, transactionHistory]
   );
 
   const goalMessages = useMemo(() => ({

--- a/src/dividendGoalUtils.test.js
+++ b/src/dividendGoalUtils.test.js
@@ -10,6 +10,10 @@ describe('dividend goal helpers', () => {
       { stock_id: '0050', total_quantity: 1000 },
       { stock_id: '00878', total_quantity: 500 }
     ];
+    const transactionHistory = [
+      { stock_id: '0050', date: '2023-12-15', quantity: 1000, type: 'buy' },
+      { stock_id: '00878', date: '2024-01-10', quantity: 500, type: 'buy' }
+    ];
     const dividendEvents = [
       { stock_id: '0050', dividend_date: '2024-01-10', dividend: '1' },
       { stock_id: '0050', dividend_date: '2024-06-10', dividend: '0.8' },
@@ -20,6 +24,7 @@ describe('dividend goal helpers', () => {
     const summary = calculateDividendSummary({
       inventoryList,
       dividendEvents,
+      transactionHistory,
       asOfDate: new Date('2024-07-01')
     });
 
@@ -28,6 +33,54 @@ describe('dividend goal helpers', () => {
       annualTotal: 1000 * 1 + 1000 * 0.8 + 500 * 0.5,
       annualYear: 2024,
       monthlyAverage: (1000 * 1 + 1000 * 0.8 + 500 * 0.5) / 12
+    });
+  });
+
+  test('uses transaction history quantity at dividend date', () => {
+    const transactionHistory = [
+      { stock_id: '0050', date: '2023-12-01', quantity: 1000, type: 'buy' },
+      { stock_id: '0050', date: '2024-02-01', quantity: 1000, type: 'sell' }
+    ];
+    const dividendEvents = [
+      { stock_id: '0050', dividend_date: '2024-01-10', dividend: '1' },
+      { stock_id: '0050', dividend_date: '2024-03-10', dividend: '1' }
+    ];
+
+    const summary = calculateDividendSummary({
+      inventoryList: [],
+      dividendEvents,
+      transactionHistory,
+      asOfDate: new Date('2024-04-01')
+    });
+
+    expect(summary).toEqual({
+      yearToDateTotal: 1000,
+      annualTotal: 1000,
+      annualYear: 2024,
+      monthlyAverage: 1000 / 12
+    });
+  });
+
+  test('falls back to inventory totals when history is unavailable', () => {
+    const inventoryList = [
+      { stock_id: '0050', total_quantity: 100 }
+    ];
+    const dividendEvents = [
+      { stock_id: '0050', dividend_date: '2024-01-10', dividend: '2' }
+    ];
+
+    const summary = calculateDividendSummary({
+      inventoryList,
+      dividendEvents,
+      transactionHistory: null,
+      asOfDate: new Date('2024-02-01')
+    });
+
+    expect(summary).toEqual({
+      yearToDateTotal: 200,
+      annualTotal: 200,
+      annualYear: 2024,
+      monthlyAverage: 200 / 12
     });
   });
 


### PR DESCRIPTION
## Summary
- compute dividend goal summaries with per-event share quantities derived from transaction history and cache identical requests
- pass the recorded transaction history into dividend summary calculations in the Home and Inventory tabs
- extend dividend summary tests to verify transaction-driven amounts and fallback behaviour

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4113f7688329bf3521639859caf5