### PR TITLE
Organize React Jest tests in dedicated folder

### DIFF
--- a/src/__tests__/AboutTab.test.jsx
+++ b/src/__tests__/AboutTab.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import AboutTab from './AboutTab';
+import AboutTab from '../AboutTab';
 
 test('renders about heading and all sections', () => {
   render(<AboutTab />);

--- a/src/__tests__/AppCalendarFilter.test.jsx
+++ b/src/__tests__/AppCalendarFilter.test.jsx
@@ -1,17 +1,17 @@
 /* eslint-env jest */
 import { render, screen, fireEvent } from '@testing-library/react';
 // Mock asset imports used by App
-jest.mock('./assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
-jest.mock('./assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('../assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('../assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
 
-jest.mock('./api', () => ({
+jest.mock('../api', () => ({
   fetchWithCache: jest.fn(() => Promise.resolve({ data: [], cacheStatus: 'fresh', timestamp: '' })),
   clearCache: jest.fn(),
 }));
 
-jest.mock('./config', () => ({ API_HOST: '' }));
+jest.mock('../config', () => ({ API_HOST: '' }));
 
-import App from './App';
+import App from '../App';
 
 beforeAll(() => {
   globalThis.fetch = jest.fn(() => Promise.resolve({}));

--- a/src/__tests__/AppCalendarVisibility.test.jsx
+++ b/src/__tests__/AppCalendarVisibility.test.jsx
@@ -1,17 +1,17 @@
 /* eslint-env jest */
 import { render, screen, fireEvent } from '@testing-library/react';
 // Mock asset imports used by App
-jest.mock('./assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
-jest.mock('./assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('../assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('../assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
 
-jest.mock('./api', () => ({
+jest.mock('../api', () => ({
   fetchWithCache: jest.fn(() => Promise.resolve({ data: [], cacheStatus: 'fresh', timestamp: '' })),
   clearCache: jest.fn(),
 }));
 
-jest.mock('./config', () => ({ API_HOST: '' }));
+jest.mock('../config', () => ({ API_HOST: '' }));
 
-import App from './App';
+import App from '../App';
 
 beforeAll(() => {
   globalThis.fetch = jest.fn(() => Promise.resolve({}));

--- a/src/__tests__/CookieConsent.test.jsx
+++ b/src/__tests__/CookieConsent.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import Cookies from 'js-cookie';
-import CookieConsent from './components/CookieConsent.jsx';
+import CookieConsent from '../components/CookieConsent.jsx';
 
 describe('CookieConsent', () => {
   beforeEach(() => {

--- a/src/__tests__/DisclaimerTab.test.jsx
+++ b/src/__tests__/DisclaimerTab.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import DisclaimerTab from './DisclaimerTab';
+import DisclaimerTab from '../DisclaimerTab';
 
 test('renders disclaimer heading', () => {
   render(<DisclaimerTab />);

--- a/src/__tests__/DividendCalendar.test.jsx
+++ b/src/__tests__/DividendCalendar.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import DividendCalendar from './DividendCalendar';
+import DividendCalendar from '../components/DividendCalendar';
 
 test('displays monthly ex and pay totals', () => {
   const nowStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' });

--- a/src/__tests__/FaqTab.test.jsx
+++ b/src/__tests__/FaqTab.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import FaqTab from './FaqTab';
+import FaqTab from '../FaqTab';
 
 test('renders faq heading', () => {
   render(<FaqTab />);

--- a/src/__tests__/Footer.test.jsx
+++ b/src/__tests__/Footer.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import Footer from './components/Footer.jsx';
-import { LanguageContext, translations } from './i18n';
+import Footer from '../components/Footer.jsx';
+import { LanguageContext, translations } from '../i18n';
 
 test('renders contact info and dynamic copyright', () => {
   const year = new Date().getFullYear();

--- a/src/__tests__/GuideTab.test.jsx
+++ b/src/__tests__/GuideTab.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import GuideTab from './GuideTab';
+import GuideTab from '../GuideTab';
 
 test('renders guide heading', () => {
   render(<GuideTab />);

--- a/src/__tests__/HomeTab.test.jsx
+++ b/src/__tests__/HomeTab.test.jsx
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import HomeTab from './HomeTab';
-import { fetchWithCache } from './api';
-import { LanguageContext, translations } from './i18n';
+import HomeTab from '../HomeTab';
+import { fetchWithCache } from '../api';
+import { LanguageContext, translations } from '../i18n';
 
-jest.mock('./api');
-jest.mock('./config', () => ({
+jest.mock('../api');
+jest.mock('../config', () => ({
   API_HOST: 'http://localhost'
 }));
 

--- a/src/__tests__/InventoryTab.test.jsx
+++ b/src/__tests__/InventoryTab.test.jsx
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Cookies from 'js-cookie';
-import InventoryTab from './InventoryTab';
-import { fetchWithCache } from './api';
+import InventoryTab from '../InventoryTab';
+import { fetchWithCache } from '../api';
 
-jest.mock('./api');
-jest.mock('./config', () => ({
+jest.mock('../api');
+jest.mock('../config', () => ({
   API_HOST: 'http://localhost'
 }));
 

--- a/src/__tests__/PrivacyPolicyTab.test.jsx
+++ b/src/__tests__/PrivacyPolicyTab.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import PrivacyPolicyTab from './PrivacyPolicyTab';
+import PrivacyPolicyTab from '../PrivacyPolicyTab';
 
 test('renders privacy policy heading', () => {
   render(<PrivacyPolicyTab />);

--- a/src/__tests__/StockDetail.test.jsx
+++ b/src/__tests__/StockDetail.test.jsx
@@ -1,9 +1,9 @@
 /* eslint-env jest */
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import StockDetail from './StockDetail';
+import StockDetail from '../StockDetail';
 
-jest.mock('./config', () => ({
+jest.mock('../config', () => ({
   API_HOST: 'http://localhost'
 }));
 

--- a/src/__tests__/TermsOfServiceTab.test.jsx
+++ b/src/__tests__/TermsOfServiceTab.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import TermsOfServiceTab from './TermsOfServiceTab';
+import TermsOfServiceTab from '../TermsOfServiceTab';
 
 test('renders terms heading', () => {
   render(<TermsOfServiceTab />);

--- a/src/__tests__/UserDividendsTab.test.jsx
+++ b/src/__tests__/UserDividendsTab.test.jsx
@@ -1,10 +1,10 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
-import UserDividendsTab from './UserDividendsTab';
-import { readTransactionHistory } from './transactionStorage';
+import UserDividendsTab from '../UserDividendsTab';
+import { readTransactionHistory } from '../transactionStorage';
 
-jest.mock('./transactionStorage');
-jest.mock('./config', () => ({ API_HOST: '' }));
+jest.mock('../transactionStorage');
+jest.mock('../config', () => ({ API_HOST: '' }));
 
 test('displays stock id and dynamic name from dividend data', async () => {
   readTransactionHistory.mockReturnValue([

--- a/src/__tests__/UserDividendsTabCalendarVisibility.test.jsx
+++ b/src/__tests__/UserDividendsTabCalendarVisibility.test.jsx
@@ -1,10 +1,10 @@
 /* eslint-env jest */
 import { render, screen, fireEvent } from '@testing-library/react';
-import UserDividendsTab from './UserDividendsTab';
-import { readTransactionHistory } from './transactionStorage';
+import UserDividendsTab from '../UserDividendsTab';
+import { readTransactionHistory } from '../transactionStorage';
 
-jest.mock('./transactionStorage');
-jest.mock('./config', () => ({ API_HOST: '' }));
+jest.mock('../transactionStorage');
+jest.mock('../config', () => ({ API_HOST: '' }));
 
 test('UserDividendsTab remembers calendar visibility', async () => {
   localStorage.clear();


### PR DESCRIPTION
## Summary
- move all React component .test.jsx files into a shared `src/__tests__` directory for easier maintenance
- update each test's relative imports and mocks to account for the new location

## Testing
- pnpm test *(fails: ReferenceError: monthlyMin is not defined in existing dividend goal helpers and related components)*

------
https://chatgpt.com/codex/tasks/task_e_68cca8f9323c832985c84a4b10ca18c0