### PR TITLE
Highlight selected dividend goal metrics

### DIFF
--- a/src/components/InvestmentGoalCard.jsx
+++ b/src/components/InvestmentGoalCard.jsx
@@ -14,12 +14,31 @@ export default function InvestmentGoalCard({ title, metrics = [], rows, savedMes
       <div className={styles.body}>
         {metrics.length > 0 ? (
           <div className={styles.metrics}>
-            {metrics.map(metric => (
-              <div key={metric.id} className={styles.metric}>
-                <div className={styles.metricLabel}>{metric.label}</div>
-                <div className={styles.metricValue}>{metric.value}</div>
-              </div>
-            ))}
+            {metrics.map(metric => {
+              const metricClassName = [
+                styles.metric,
+                metric.isActive ? styles.metricActive : '',
+                metric.highlight ? styles.metricHighlight : '',
+                metric.showCelebration ? styles.metricCelebrate : ''
+              ].filter(Boolean).join(' ');
+              const metricValueClassName = [
+                styles.metricValue,
+                metric.showCelebration ? styles.metricValueCelebrate : ''
+              ].filter(Boolean).join(' ');
+              return (
+                <div key={metric.id} className={metricClassName}>
+                  <div className={styles.metricLabel}>{metric.label}</div>
+                  <div className={metricValueClassName}>
+                    {metric.value}
+                    {metric.showCelebration ? (
+                      <span className={styles.metricCelebrateIcon} aria-hidden="true">
+                        🎆
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         ) : null}
         {rows.map(row => (

--- a/src/components/InvestmentGoalCard.module.css
+++ b/src/components/InvestmentGoalCard.module.css
@@ -59,6 +59,8 @@
   padding: 8px 12px;
   border-radius: 8px;
   background: rgba(148, 163, 184, 0.12);
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .metricLabel {
@@ -69,6 +71,41 @@
 .metricValue {
   font-size: 1.1rem;
   font-weight: 600;
+}
+
+.metricActive {
+  background: rgba(250, 204, 21, 0.18);
+  border-color: rgba(250, 204, 21, 0.45);
+}
+
+.metricActive .metricLabel,
+.metricActive .metricValue {
+  color: var(--accent-gold);
+}
+
+.metricHighlight {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.metricHighlight .metricLabel,
+.metricHighlight .metricValue {
+  color: #22c55e;
+}
+
+.metricCelebrate {
+  box-shadow: 0 6px 18px rgba(34, 197, 94, 0.25);
+}
+
+.metricValueCelebrate {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.metricCelebrateIcon {
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 .goalRow {

--- a/src/utils/dividendGoalUtils.js
+++ b/src/utils/dividendGoalUtils.js
@@ -273,22 +273,27 @@ export function buildDividendGoalViewModel({ summary = {}, goals = {}, messages 
       label: annualTotal > 0 && annualYear
         ? `${messages.goalDividendAnnualLabel} (${annualYear})`
         : messages.goalDividendAnnualLabel,
-      value: formatCurrency(annualTotal)
+      value: formatCurrency(annualTotal),
+      isActive: activeGoalType === 'annual'
     },
     {
       id: 'monthly',
       label: messages.goalDividendMonthlyLabel,
-      value: formatCurrency(monthlyAverage)
+      value: formatCurrency(monthlyAverage),
+      isActive: activeGoalType === 'monthly'
     },
     {
       id: 'minimum',
       label: messages.goalDividendMinimumLabel,
-      value: formatCurrency(monthlyMinimum)
+      value: formatCurrency(monthlyMinimum),
+      isActive: activeGoalType === 'minimum'
     },
     {
       id: 'achievement',
       label: messages.goalAchievementLabel,
-      value: achievementLabel
+      value: achievementLabel,
+      highlight: achievementPercentValue >= 0.5,
+      showCelebration: achievementPercentValue >= 1
     }
   ].filter(metric => Boolean(metric.label));
 

--- a/tests/dividendGoalUtils.test.js
+++ b/tests/dividendGoalUtils.test.js
@@ -130,11 +130,11 @@ describe('dividend goal helpers', () => {
     });
 
     expect(metrics).toEqual([
-      { id: 'ytd', label: '累積股息', value: '1800' },
-      { id: 'annual', label: '年度股息 (2024)', value: '2400' },
-      { id: 'monthly', label: '每月平均股息', value: '200' },
-      { id: 'minimum', label: '每月最低股息', value: '120' },
-      { id: 'achievement', label: '達成率', value: '50%' }
+      expect.objectContaining({ id: 'ytd', label: '累積股息', value: '1800' }),
+      expect.objectContaining({ id: 'annual', label: '年度股息 (2024)', value: '2400', isActive: true }),
+      expect.objectContaining({ id: 'monthly', label: '每月平均股息', value: '200' }),
+      expect.objectContaining({ id: 'minimum', label: '每月最低股息', value: '120' }),
+      expect.objectContaining({ id: 'achievement', label: '達成率', value: '50%', highlight: true, showCelebration: false })
     ]);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
@@ -244,5 +244,53 @@ describe('dividend goal helpers', () => {
 
     const achievementMetric = metrics.find(metric => metric.id === 'achievement');
     expect(achievementMetric.value).toBe('50%');
+    expect(achievementMetric.highlight).toBe(true);
+    expect(achievementMetric.showCelebration).toBe(false);
+  });
+
+  test('celebrates achievement when reaching 100 percent', () => {
+    const summary = {
+      accumulatedTotal: 3600,
+      annualTotal: 3600,
+      annualYear: 2024,
+      monthlyAverage: 300,
+      monthlyMinimum: 200
+    };
+    const messages = {
+      annualGoal: '年度目標',
+      monthlyGoal: '每月目標',
+      minimumGoal: '最低目標',
+      goalDividendAccumulated: '累積股息：',
+      goalDividendMonthly: '每月平均股息：',
+      goalDividendMinimum: '每月最低股息：',
+      goalDividendYtdLabel: '累積股息',
+      goalDividendAnnualLabel: '年度股息',
+      goalDividendMonthlyLabel: '每月平均股息',
+      goalDividendMinimumLabel: '每月最低股息',
+      goalAchievementLabel: '達成率',
+      goalTargetAnnual: '年度目標：',
+      goalTargetMonthly: '每月目標：',
+      goalTargetMinimum: '每月最低目標：',
+      goalPercentPlaceholder: '--',
+      goalAnnualHalf: '年度過半',
+      goalAnnualDone: '年度完成',
+      goalMonthlyHalf: '月過半',
+      goalMonthlyDone: '月完成',
+      goalMinimumHalf: '月最低過半',
+      goalMinimumDone: '月最低完成',
+      goalEmpty: ''
+    };
+
+    const { metrics } = buildDividendGoalViewModel({
+      summary,
+      goals: { totalTarget: 3600, monthlyTarget: 0, minimumTarget: 0, goalType: 'annual' },
+      messages,
+      formatCurrency: value => Number(value).toFixed(0)
+    });
+
+    const achievementMetric = metrics.find(metric => metric.id === 'achievement');
+    expect(achievementMetric.value).toBe('100%');
+    expect(achievementMetric.highlight).toBe(true);
+    expect(achievementMetric.showCelebration).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- highlight the dividend metric that matches the selected goal type and show fireworks when achievement reaches 100%
- update InvestmentGoalCard styling to support active and celebratory metric states
- extend dividend goal view model logic and tests to cover the new highlighting behavior

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd4f138f5483299410abf89fb92b8f