### PR TITLE
Adjust goal form inputs for light theme

### DIFF
--- a/src/components/InvestmentGoalCard.module.css
+++ b/src/components/InvestmentGoalCard.module.css
@@ -168,7 +168,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  align-items: flex-end;
+  align-items: flex-start;
 }
 
 .formIntro {
@@ -190,12 +190,13 @@
   color: var(--muted-foreground, #6b7280);
 }
 
-.inputGroup input {
+.inputGroup input,
+.inputGroup select {
   padding: 6px 8px;
   border-radius: 6px;
   border: 1px solid var(--color-border, rgba(148, 163, 184, 0.3));
-  background: var(--color-background, #111827);
-  color: inherit;
+  background: var(--color-card-bg, #ffffff);
+  color: var(--color-text, inherit);
 }
 
 .inputHelper {


### PR DESCRIPTION
## Summary
- align the goal form input groups from the top so labels line up evenly
- reuse the card background and text color variables for goal form inputs and the select so light themes remain legible

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd52932f388329acab6446958c8aca