### PR TITLE
Intensify investment goal form labels

### DIFF
--- a/src/components/InvestmentGoalCard.module.css
+++ b/src/components/InvestmentGoalCard.module.css
@@ -187,7 +187,8 @@
 
 .inputGroup label {
   font-size: 0.75rem;
-  color: var(--muted-foreground, #6b7280);
+  color: var(--color-text, #1f2937);
+  font-weight: 600;
 }
 
 .inputGroup input,


### PR DESCRIPTION
## Summary
- darken the investment goal form labels to improve legibility
- add font weight to the labels for additional emphasis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5c67ec588329a59d371d29a402ab