### PR TITLE
Add share accumulation targets to investment goals

### DIFF
--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -83,3 +83,66 @@
   font-weight: bold;
   /* margin: 4px 0; */
 }
+
+.shareGoalSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shareGoalHeader {
+  font-weight: 600;
+}
+
+.shareGoalList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shareGoalRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.shareGoalInput {
+  flex: 1 1 160px;
+  min-width: 140px;
+}
+
+.shareGoalActions {
+  display: flex;
+  align-items: flex-end;
+}
+
+.shareGoalActions button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.3));
+  background: var(--color-card-bg, #ffffff);
+  color: inherit;
+  cursor: pointer;
+}
+
+.shareGoalActions button:hover,
+.shareGoalActions button:focus-visible {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.shareGoalAddButton {
+  background: var(--accent-gold);
+  border: none;
+  color: var(--color-text);
+}
+
+.shareGoalAddButton:hover,
+.shareGoalAddButton:focus-visible {
+  opacity: 0.85;
+}
+
+.shareGoalEmpty {
+  font-size: 0.85rem;
+  color: var(--muted-foreground, #6b7280);
+}

--- a/src/components/InvestmentGoalCard.jsx
+++ b/src/components/InvestmentGoalCard.jsx
@@ -3,6 +3,16 @@ import styles from './InvestmentGoalCard.module.css';
 export default function InvestmentGoalCard({ title, metrics = [], rows, savedMessage, form, emptyState }) {
   const { isVisible: formIsVisible = true, toggle: formToggle, id: formId, ...formProps } = form || {};
   const typeOptions = Array.isArray(formProps.typeOptions) ? formProps.typeOptions : [];
+  const formSections = Array.isArray(formProps.sections)
+    ? formProps.sections.map((section, index) => {
+        const content = typeof section?.render === 'function' ? section.render() : section?.content;
+        if (!content) return null;
+        return {
+          key: section.id || section.key || `section-${index}`,
+          content
+        };
+      }).filter(Boolean)
+    : [];
   const shouldRenderForm = Boolean(form) && formIsVisible !== false;
 
   return (
@@ -126,6 +136,11 @@ export default function InvestmentGoalCard({ title, metrics = [], rows, savedMes
                 step={formProps.targetStep || '100'}
               />
             </div>
+            {formSections.map(section => (
+              <div key={section.key} className={styles.formSection}>
+                {section.content}
+              </div>
+            ))}
             <div className={styles.inputGroup}>
               <label>{formProps.saveLabel}</label>
               <button type="submit" style={{ width: "fit-content" }}>{formProps.saveButton}</button>

--- a/src/components/InvestmentGoalCard.module.css
+++ b/src/components/InvestmentGoalCard.module.css
@@ -171,6 +171,13 @@
   align-items: flex-start;
 }
 
+.formSection {
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .formIntro {
   flex-basis: 100%;
   margin: 0;

--- a/tests/InventoryTab.test.jsx
+++ b/tests/InventoryTab.test.jsx
@@ -52,6 +52,26 @@ describe('InventoryTab interactions', () => {
     expect(screen.getByPlaceholderText('例：5000')).toBeInTheDocument();
   });
 
+  test('allows adding share accumulation goals', async () => {
+    render(<InventoryTab />);
+    const toggle = await screen.findByRole('button', { name: '設定或更新目標' });
+    fireEvent.click(toggle);
+
+    const codeInput = screen.getByLabelText('股票代碼');
+    fireEvent.change(codeInput, { target: { value: '0056' } });
+    const lotsInput = screen.getByPlaceholderText('例：100');
+    fireEvent.change(lotsInput, { target: { value: '100' } });
+    fireEvent.click(screen.getByRole('button', { name: '新增存股目標' }));
+
+    fireEvent.click(screen.getByRole('button', { name: '儲存' }));
+
+    await screen.findByText('目標張數：100 張');
+    const saved = JSON.parse(localStorage.getItem('investment_goals'));
+    expect(saved.shareTargets).toEqual([
+      { stockId: '0056', stockName: '', targetQuantity: 100 }
+    ]);
+  });
+
   test('displays total investment amount and value', async () => {
     localStorage.setItem('my_transaction_history', JSON.stringify([
       { stock_id: '0050', date: '2024-01-01', quantity: 1000, type: 'buy', price: 10 }


### PR DESCRIPTION
## Summary
- allow users to configure per-ETF share accumulation targets and view progress next to dividend goals
- persist share targets in local storage and extend the goal form UI with editable rows
- update InvestmentGoalCard to support extra sections and add regression tests for the new workflow

## Testing
- npm test -- --runTestsByPath tests/InventoryTab.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68cd76e40e94832993868c575e877d2d