### PR TITLE
Add share goal type toggle

### DIFF
--- a/src/InventoryTab.module.css
+++ b/src/InventoryTab.module.css
@@ -112,6 +112,22 @@
   min-width: 140px;
 }
 
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.inputGroup label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text, #1f2937);
+}
+
+.shareGoalSelect {
+  width: 100%;
+}
+
 .shareGoalActions {
   display: flex;
   align-items: flex-end;

--- a/src/components/AddTransactionModal.jsx
+++ b/src/components/AddTransactionModal.jsx
@@ -1,34 +1,7 @@
 import Select from 'react-select';
 import styles from './AddTransactionModal.module.css';
 import { useLanguage } from '../i18n';
-
-const selectStyles = {
-  control: provided => ({
-    ...provided,
-    backgroundColor: 'var(--color-card-bg)',
-    borderColor: 'var(--color-border)',
-    color: 'var(--color-text)'
-  }),
-  input: provided => ({
-    ...provided,
-    color: 'var(--color-text)'
-  }),
-  singleValue: provided => ({
-    ...provided,
-    color: 'var(--color-text)'
-  }),
-  menu: provided => ({
-    ...provided,
-    backgroundColor: 'var(--color-card-bg)',
-    color: 'var(--color-text)',
-    zIndex: 1100
-  }),
-  option: (provided, state) => ({
-    ...provided,
-    backgroundColor: state.isFocused ? 'var(--color-row-even)' : 'var(--color-card-bg)',
-    color: 'var(--color-text)'
-  })
-};
+import selectStyles from '../selectStyles';
 
 export default function AddTransactionModal({ show, onClose, stockList, form, setForm, onSubmit }) {
   const { lang } = useLanguage();

--- a/src/components/InvestmentGoalCard.jsx
+++ b/src/components/InvestmentGoalCard.jsx
@@ -13,6 +13,7 @@ export default function InvestmentGoalCard({ title, metrics = [], rows, savedMes
         };
       }).filter(Boolean)
     : [];
+  const shouldShowTargetInput = !formProps.targetHidden && Boolean(formProps.targetLabel);
   const shouldRenderForm = Boolean(form) && formIsVisible !== false;
 
   return (
@@ -123,19 +124,21 @@ export default function InvestmentGoalCard({ title, metrics = [], rows, savedMes
                 </select>
               </div>
             ) : null}
-            <div className={styles.inputGroup}>
-              <label htmlFor={formProps.targetId}>{formProps.targetLabel}</label>
-              <input
-                id={formProps.targetId}
-                type="number"
-                inputMode="decimal"
-                value={formProps.targetValue}
-                onChange={formProps.onTargetChange}
-                placeholder={formProps.targetPlaceholder}
-                min={formProps.targetMin || '0'}
-                step={formProps.targetStep || '100'}
-              />
-            </div>
+            {shouldShowTargetInput ? (
+              <div className={styles.inputGroup}>
+                <label htmlFor={formProps.targetId}>{formProps.targetLabel}</label>
+                <input
+                  id={formProps.targetId}
+                  type="number"
+                  inputMode="decimal"
+                  value={formProps.targetValue}
+                  onChange={formProps.onTargetChange}
+                  placeholder={formProps.targetPlaceholder}
+                  min={formProps.targetMin || '0'}
+                  step={formProps.targetStep || '100'}
+                />
+              </div>
+            ) : null}
             {formSections.map(section => (
               <div key={section.key} className={styles.formSection}>
                 {section.content}

--- a/src/selectStyles.js
+++ b/src/selectStyles.js
@@ -1,0 +1,29 @@
+const selectStyles = {
+  control: provided => ({
+    ...provided,
+    backgroundColor: 'var(--color-card-bg)',
+    borderColor: 'var(--color-border)',
+    color: 'var(--color-text)'
+  }),
+  input: provided => ({
+    ...provided,
+    color: 'var(--color-text)'
+  }),
+  singleValue: provided => ({
+    ...provided,
+    color: 'var(--color-text)'
+  }),
+  menu: provided => ({
+    ...provided,
+    backgroundColor: 'var(--color-card-bg)',
+    color: 'var(--color-text)',
+    zIndex: 1100
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    backgroundColor: state.isFocused ? 'var(--color-row-even)' : 'var(--color-card-bg)',
+    color: 'var(--color-text)'
+  })
+};
+
+export default selectStyles;

--- a/tests/InventoryTab.test.jsx
+++ b/tests/InventoryTab.test.jsx
@@ -57,8 +57,15 @@ describe('InventoryTab interactions', () => {
     const toggle = await screen.findByRole('button', { name: '設定或更新目標' });
     fireEvent.click(toggle);
 
-    const codeInput = screen.getByLabelText('股票代碼');
+    expect(screen.queryByRole('button', { name: '新增存股目標' })).not.toBeInTheDocument();
+
+    const goalTypeSelect = screen.getByLabelText('選擇目標類型');
+    fireEvent.change(goalTypeSelect, { target: { value: 'shares' } });
+    expect(screen.queryByPlaceholderText('例：50000')).not.toBeInTheDocument();
+
+    const codeInput = screen.getByLabelText('股票代碼 / 名稱');
     fireEvent.change(codeInput, { target: { value: '0056' } });
+    fireEvent.keyDown(codeInput, { key: 'Enter', code: 'Enter', charCode: 13 });
     const lotsInput = screen.getByPlaceholderText('例：100');
     fireEvent.change(lotsInput, { target: { value: '100' } });
     fireEvent.click(screen.getByRole('button', { name: '新增存股目標' }));
@@ -67,6 +74,7 @@ describe('InventoryTab interactions', () => {
 
     await screen.findByText('目標張數：100 張');
     const saved = JSON.parse(localStorage.getItem('investment_goals'));
+    expect(saved.goalType).toBe('shares');
     expect(saved.shareTargets).toEqual([
       { stockId: '0056', stockName: '', targetQuantity: 100 }
     ]);


### PR DESCRIPTION
## Summary
- add a shares goal option to the investment goal type selector and only surface the share target editor when that option is chosen
- hide the currency goal input for share goals while keeping data normalized in storage, including support for persisting the new goal type
- extend the inventory tab tests to drive the goal type switch and verify share goal persistence

## Testing
- pnpm lint
- pnpm test --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68ce36382a3883299f9b9b7081e17e7e