### PR TITLE
Raise dropdown z-index for filter overlays

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -146,7 +146,7 @@ td {
 
 .dropdown {
   position: absolute;
-  z-index: 99;
+  z-index: 1200;
   top: 30px;
   left: 0;
   background: var(--color-card-bg);
@@ -292,7 +292,7 @@ td {
 /* Action dropdown for top controls */
 .action-dropdown {
   position: absolute;
-  z-index: 99;
+  z-index: 1200;
   top: 36px;
   left: 0;
   background: var(--color-card-bg);


### PR DESCRIPTION
## Summary
- increase the dropdown stacking level so stock search filters are rendered above other layout elements
- align the action dropdown stacking order to match the higher overlay level

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce8ff1d5108329a9c7651853640f25