### PR TITLE
Hide share goal progress when not in share mode

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -1022,12 +1022,20 @@ export default function InventoryTab() {
     }).filter(Boolean);
   }, [goals.shareTargets, inventoryList, msg.shareGoalCurrent, msg.shareGoalTargetDisplay, msg.shareGoalUnit, msg.shareGoalHalf, msg.shareGoalDone]);
 
+  const normalizedSavedGoalType = GOAL_TYPES.includes(goals.goalType)
+    ? goals.goalType
+    : DEFAULT_GOAL_TYPE;
+
   const combinedGoalRows = useMemo(
-    () => [...goalRows, ...shareGoalRows],
-    [goalRows, shareGoalRows]
+    () => (normalizedSavedGoalType === 'shares'
+      ? [...goalRows, ...shareGoalRows]
+      : goalRows),
+    [goalRows, shareGoalRows, normalizedSavedGoalType]
   );
 
-  const combinedGoalEmptyState = shareGoalRows.length > 0 ? '' : goalEmptyState;
+  const combinedGoalEmptyState = normalizedSavedGoalType === 'shares' && shareGoalRows.length > 0
+    ? ''
+    : goalEmptyState;
 
   const goalSavedMessage = goalSaved === 'empty'
     ? msg.goalSavedEmpty


### PR DESCRIPTION
## Summary
- ignore share accumulation progress rows unless the saved goal type is set to shares
- ensure the goal card empty state still comes from dividend goals when share targets are hidden

## Testing
- pnpm test -- --runTestsByPath tests/InventoryTab.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68cea3c67b7883299d57cf7a98d286a8