### PR TITLE
Fix payment calendar totals when ex-date missing

### DIFF
--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -77,7 +77,8 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
 
     // Events for calendar view
     const calendarEvents = dividendData.flatMap(item => {
-        const qty = getHolding(item.stock_id, item.dividend_date);
+        const holdingDate = item.dividend_date || item.payment_date;
+        const qty = getHolding(item.stock_id, holdingDate);
         const dividend = parseFloat(item.dividend);
         const amount = dividend * qty;
         const dividend_yield = parseFloat(item.dividend_yield) || 0;

--- a/tests/UserDividendsTab.test.jsx
+++ b/tests/UserDividendsTab.test.jsx
@@ -45,6 +45,30 @@ test('calendar defaults to showing both ex and payment events', async () => {
   expect(bothBtn).toHaveClass('btn-selected');
 });
 
+test('payment totals fall back to payment date holdings when ex-date missing', async () => {
+  const nowStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' });
+  const [year, month] = nowStr.split('-');
+  readTransactionHistory.mockReturnValue([
+    { stock_id: 'BBB', date: `${year}-01-10`, quantity: 1000, type: 'buy' }
+  ]);
+
+  const data = [
+    {
+      stock_id: 'BBB',
+      stock_name: 'BBB ETF',
+      dividend: '2.5',
+      dividend_date: null,
+      payment_date: `${year}-${month}-18`,
+      dividend_yield: '3',
+      last_close_price: '40'
+    }
+  ];
+
+  render(<UserDividendsTab allDividendData={data} selectedYear={Number(year)} />);
+
+  expect(await screen.findByText('發放金額: 2,500')).toBeInTheDocument();
+});
+
 test('shows dividends for stocks sold before year end', async () => {
   readTransactionHistory.mockReturnValue([
     { stock_id: '0056', date: '2024-01-01', quantity: 1000, type: 'buy' },


### PR DESCRIPTION
## Summary
- ensure user dividend calendar calculates payment totals using the payment date when an ex-date is missing
- add a regression test covering the missing ex-date scenario

## Testing
- pnpm test -- UserDividendsTab.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d51bf4f0b483298cd4b441801e84a3