### PR TITLE
Allow configuring Microsoft Graph base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,23 @@ If you are developing a production application, we recommend using TypeScript wi
 ## OneDrive Backup
 
 To enable OneDrive import and export, create an Azure application with Microsoft Graph permissions (e.g. `Files.ReadWrite`).
-Set your app's redirect URI to your site's origin. Then add the client ID and desired scopes to a `.env` file:
+Set your app's redirect URI to your site's origin. Then add the client ID, desired scopes, and optional authority to a `.env`
+file. You can also override the Microsoft Graph base URL when using a national Azure cloud (e.g. China or US Gov) or a
+sovereign deployment:
 
 ```
 VITE_ONEDRIVE_CLIENT_ID=your_client_id
 VITE_ONEDRIVE_SCOPES=Files.ReadWrite
+VITE_ONEDRIVE_AUTHORITY=https://login.microsoftonline.com/common
+VITE_ONEDRIVE_GRAPH_BASE=https://graph.microsoft.com
 ```
 
-Restart the development server after updating the file. Use the data menu to authorize and transfer backups with OneDrive.
+Restart the development server after updating the file. Use the data menu to authorize and transfer backups with OneDrive. Each
+person signs in with their own Microsoft account, and the app will prompt them to choose the desired profile if multiple
+accounts are available in the browser session. Set `VITE_ONEDRIVE_AUTHORITY` to `https://login.microsoftonline.com/consumers`
+when the app registration only allows personal Microsoft accounts, or to a tenant-specific authority when the registration is
+single tenant. Use the appropriate `VITE_ONEDRIVE_GRAPH_BASE` for Azure China (`https://microsoftgraph.chinacloudapi.cn`), US
+Government (`https://graph.microsoft.us`), or other clouds so API calls reach the correct Microsoft Graph endpoint.
 
 ## Google Drive Backup
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
         window.GOOGLE_API_KEY = '%VITE_GOOGLE_API_KEY%';
         window.ONEDRIVE_CLIENT_ID = '%VITE_ONEDRIVE_CLIENT_ID%';
         window.ONEDRIVE_SCOPES = '%VITE_ONEDRIVE_SCOPES%';
+        window.ONEDRIVE_AUTHORITY = '%VITE_ONEDRIVE_AUTHORITY%';
+        window.ONEDRIVE_GRAPH_BASE = '%VITE_ONEDRIVE_GRAPH_BASE%';
       </script>
     <title>Dividend Life</title>
   </head>

--- a/src/oneDrive.js
+++ b/src/oneDrive.js
@@ -1,10 +1,25 @@
 import { transactionsToCsv, transactionsFromCsv } from './utils/csvUtils';
 
-const CLIENT_ID = typeof window !== 'undefined' && window.ONEDRIVE_CLIENT_ID ? window.ONEDRIVE_CLIENT_ID : '';
-const SCOPES = typeof window !== 'undefined' && window.ONEDRIVE_SCOPES ? window.ONEDRIVE_SCOPES.split(' ') : ['Files.ReadWrite'];
+const CLIENT_ID =
+  typeof window !== 'undefined' && window.ONEDRIVE_CLIENT_ID && window.ONEDRIVE_CLIENT_ID !== 'undefined'
+    ? window.ONEDRIVE_CLIENT_ID
+    : '';
+const SCOPES =
+  typeof window !== 'undefined' && window.ONEDRIVE_SCOPES && window.ONEDRIVE_SCOPES !== 'undefined'
+    ? window.ONEDRIVE_SCOPES.split(' ').filter(Boolean)
+    : ['Files.ReadWrite'];
+const AUTHORITY =
+  typeof window !== 'undefined' && window.ONEDRIVE_AUTHORITY && window.ONEDRIVE_AUTHORITY !== 'undefined'
+    ? window.ONEDRIVE_AUTHORITY
+    : 'https://login.microsoftonline.com/common';
+const GRAPH_BASE =
+  typeof window !== 'undefined' && window.ONEDRIVE_GRAPH_BASE && window.ONEDRIVE_GRAPH_BASE !== 'undefined'
+    ? window.ONEDRIVE_GRAPH_BASE.replace(/\/$/, '')
+    : 'https://graph.microsoft.com';
 let msalInstance = null;
 let accessToken = null;
 let msalLoaded = false;
+let activeAccount = null;
 
 async function loadMsal() {
   if (msalLoaded) return;
@@ -24,21 +39,27 @@ export async function initOneDrive() {
   await loadMsal();
   if (!msalInstance) {
     msalInstance = new window.msal.PublicClientApplication({
-      auth: { clientId: CLIENT_ID, redirectUri: window.location.origin }
+      auth: { clientId: CLIENT_ID, authority: AUTHORITY, redirectUri: window.location.origin }
     });
   }
+  if (!activeAccount) {
+    activeAccount = msalInstance.getActiveAccount() || msalInstance.getAllAccounts()[0] || null;
+  }
   if (accessToken) return accessToken;
-  const accounts = msalInstance.getAllAccounts();
-  if (accounts.length > 0) {
+  if (activeAccount) {
     try {
-      const res = await msalInstance.acquireTokenSilent({ scopes: SCOPES, account: accounts[0] });
+      const res = await msalInstance.acquireTokenSilent({ scopes: SCOPES, account: activeAccount });
       accessToken = res.accessToken;
       return accessToken;
     } catch {
       // fallback to interactive login
     }
   }
-  const res = await msalInstance.loginPopup({ scopes: SCOPES });
+  const res = await msalInstance.loginPopup({ scopes: SCOPES, prompt: 'select_account' });
+  if (res.account) {
+    activeAccount = res.account;
+    msalInstance.setActiveAccount(res.account);
+  }
   accessToken = res.accessToken;
   return accessToken;
 }
@@ -47,7 +68,7 @@ export async function exportTransactionsToOneDrive(list) {
   const token = await initOneDrive();
   if (!token) return;
   const csv = transactionsToCsv(list);
-  await fetch('https://graph.microsoft.com/v1.0/me/drive/root:/inventory_backup.csv:/content', {
+  await fetch(`${GRAPH_BASE}/v1.0/me/drive/root:/inventory_backup.csv:/content`, {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -61,7 +82,7 @@ export async function importTransactionsFromOneDrive() {
   const token = await initOneDrive();
   if (!token) return null;
   try {
-    const res = await fetch('https://graph.microsoft.com/v1.0/me/drive/root:/inventory_backup.csv:/content', {
+    const res = await fetch(`${GRAPH_BASE}/v1.0/me/drive/root:/inventory_backup.csv:/content`, {
       headers: { Authorization: `Bearer ${token}` }
     });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- inject the configured Microsoft Graph base URL into the client bootstrap alongside the OneDrive credentials
- allow the OneDrive integration to override the Microsoft Graph host while defaulting to the public cloud endpoint
- document how to choose the correct Graph base URL for Azure sovereign clouds

## Testing
- pnpm test -- --runTestsByPath tests/googleDrive.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d52db55bd883298603ed7686a8afef