### PR TITLE
Disable auto-save by default

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -49,7 +49,7 @@ export default function InventoryTab() {
   const [cacheInfo, setCacheInfo] = useState(null);
   const [showDataMenu, setShowDataMenu] = useState(false);
   const [selectedDataSource, setSelectedDataSource] = useState('csv');
-  const [autoSaveEnabled, setAutoSaveEnabled] = useState(true);
+  const [autoSaveEnabled, setAutoSaveEnabled] = useState(false);
   const [autoSaveState, setAutoSaveState] = useState({ status: 'idle', provider: 'csv' });
   const [latestPrices, setLatestPrices] = useState({});
   const [dividendData, setDividendData] = useState([]);
@@ -438,10 +438,7 @@ export default function InventoryTab() {
   const handleDataSourceChange = useCallback(
     value => {
       setSelectedDataSource(value);
-      if (!autoSaveEnabled) {
-        setAutoSaveEnabled(true);
-      }
-      runAutoSave(transactionHistory, { provider: value, force: true });
+      runAutoSave(transactionHistory, { provider: value, force: autoSaveEnabled });
     },
     [autoSaveEnabled, runAutoSave, transactionHistory]
   );


### PR DESCRIPTION
## Summary
- disable inventory auto-save by default so users opt in explicitly
- avoid turning auto-save on automatically when switching backup providers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d535a25a4083298de3a7e3e9bdbe6a