### PR TITLE
Improve OneDrive authentication handling

### DIFF
--- a/src/InventoryTab.jsx
+++ b/src/InventoryTab.jsx
@@ -558,7 +558,8 @@ export default function InventoryTab() {
       alert(msg.exportOneDriveSuccess);
     } catch (err) {
       console.error('OneDrive manual export failed', err);
-      alert(msg.exportOneDriveFail);
+      const errorMessage = err?.message ? `${msg.exportOneDriveFail}\n${err.message}` : msg.exportOneDriveFail;
+      alert(errorMessage);
     }
   };
 
@@ -587,7 +588,8 @@ export default function InventoryTab() {
       if (typeof window !== 'undefined') window.location.reload();
     } catch (err) {
       console.error('OneDrive manual import failed', err);
-      alert(msg.importOneDriveFail);
+      const errorMessage = err?.message ? `${msg.importOneDriveFail}\n${err.message}` : msg.importOneDriveFail;
+      alert(errorMessage);
     }
   };
 

--- a/src/oneDrive.js
+++ b/src/oneDrive.js
@@ -4,10 +4,12 @@ const CLIENT_ID =
   typeof window !== 'undefined' && window.ONEDRIVE_CLIENT_ID && window.ONEDRIVE_CLIENT_ID !== 'undefined'
     ? window.ONEDRIVE_CLIENT_ID
     : '';
-const SCOPES =
+const RAW_SCOPES =
   typeof window !== 'undefined' && window.ONEDRIVE_SCOPES && window.ONEDRIVE_SCOPES !== 'undefined'
-    ? window.ONEDRIVE_SCOPES.split(' ').filter(Boolean)
-    : ['Files.ReadWrite'];
+    ? window.ONEDRIVE_SCOPES
+    : '';
+const DEFAULT_SCOPES = ['Files.ReadWrite'];
+const BASE_OPENID_SCOPES = ['openid', 'profile'];
 const AUTHORITY =
   typeof window !== 'undefined' && window.ONEDRIVE_AUTHORITY && window.ONEDRIVE_AUTHORITY !== 'undefined'
     ? window.ONEDRIVE_AUTHORITY
@@ -21,71 +23,203 @@ let accessToken = null;
 let msalLoaded = false;
 let activeAccount = null;
 
+const SCOPES = (() => {
+  const input = typeof RAW_SCOPES === 'string' ? RAW_SCOPES : '';
+  const requested = input
+    .split(/[\s,]+/)
+    .map(scope => scope.trim())
+    .filter(Boolean);
+  const allScopes = new Set([...DEFAULT_SCOPES, ...BASE_OPENID_SCOPES, ...requested]);
+  allScopes.add('offline_access');
+  return Array.from(allScopes);
+})();
+
 async function loadMsal() {
   if (msalLoaded) return;
   await new Promise((resolve, reject) => {
+    const existing = document.getElementById('msal-sdk');
+    if (existing) {
+      msalLoaded = true;
+      resolve();
+      return;
+    }
     const script = document.createElement('script');
     script.id = 'msal-sdk';
     script.src = 'https://alcdn.msauth.net/browser/2.38.0/js/msal-browser.min.js';
-    script.onload = () => { msalLoaded = true; resolve(); };
+    script.onload = () => {
+      msalLoaded = true;
+      resolve();
+    };
     script.onerror = reject;
     document.body.appendChild(script);
   });
 }
 
-export async function initOneDrive() {
-  if (typeof window === 'undefined') return null;
-  if (!CLIENT_ID) throw new Error('OneDrive Client ID missing');
+async function ensureMsalInstance() {
+  if (typeof window === 'undefined') {
+    throw new Error('OneDrive integration requires a browser environment');
+  }
+  if (!CLIENT_ID) {
+    throw new Error('OneDrive Client ID missing');
+  }
   await loadMsal();
   if (!msalInstance) {
     msalInstance = new window.msal.PublicClientApplication({
-      auth: { clientId: CLIENT_ID, authority: AUTHORITY, redirectUri: window.location.origin }
+      auth: {
+        clientId: CLIENT_ID,
+        authority: AUTHORITY,
+        redirectUri: window.location.origin
+      },
+      cache: {
+        cacheLocation: 'localStorage',
+        storeAuthStateInCookie: false
+      }
     });
+    if (typeof msalInstance.initialize === 'function') {
+      await msalInstance.initialize();
+    }
   }
   if (!activeAccount) {
     activeAccount = msalInstance.getActiveAccount() || msalInstance.getAllAccounts()[0] || null;
-  }
-  if (accessToken) return accessToken;
-  if (activeAccount) {
-    try {
-      const res = await msalInstance.acquireTokenSilent({ scopes: SCOPES, account: activeAccount });
-      accessToken = res.accessToken;
-      return accessToken;
-    } catch {
-      // fallback to interactive login
+    if (activeAccount) {
+      msalInstance.setActiveAccount(activeAccount);
     }
   }
-  const res = await msalInstance.loginPopup({ scopes: SCOPES, prompt: 'select_account' });
-  if (res.account) {
-    activeAccount = res.account;
-    msalInstance.setActiveAccount(res.account);
+}
+
+function normalizeMsalError(error) {
+  if (!error) return new Error('Unknown OneDrive authentication error');
+  const message = typeof error.message === 'string' ? error.message : '';
+  const errorCode = typeof error.errorCode === 'string' ? error.errorCode : '';
+  if (/invalid_client/i.test(message) || errorCode === 'invalid_client' || /AADSTS70002/.test(message)) {
+    return new Error(
+      'OneDrive authentication failed because the Azure application expects a client secret. ' +
+        'Update the app registration to use the “Single-page application” platform (public client) ' +
+        'or enable the OAuth public client flow.'
+    );
   }
-  accessToken = res.accessToken;
+  if (error instanceof Error) return error;
+  return new Error(message || 'Unknown OneDrive authentication error');
+}
+
+function requiresInteraction(error) {
+  if (!error) return false;
+  const code = typeof error.errorCode === 'string' ? error.errorCode : '';
+  if (code) {
+    const lower = code.toLowerCase();
+    if (lower.includes('consent_required') || lower.includes('interaction_required')) {
+      return true;
+    }
+  }
+  if (typeof window !== 'undefined' && window.msal && window.msal.InteractionRequiredAuthError) {
+    return error instanceof window.msal.InteractionRequiredAuthError;
+  }
+  const message = typeof error.message === 'string' ? error.message : '';
+  return /consent required/i.test(message) || /interaction required/i.test(message);
+}
+
+async function acquireAccessToken(options = {}) {
+  const { forceLogin = false } = options;
+  await ensureMsalInstance();
+
+  const request = { scopes: SCOPES };
+  if (activeAccount) {
+    request.account = activeAccount;
+  }
+
+  const trySilent = async () => {
+    if (!activeAccount) return null;
+    try {
+      const result = await msalInstance.acquireTokenSilent(request);
+      if (result?.account) {
+        activeAccount = result.account;
+        msalInstance.setActiveAccount(result.account);
+      }
+      return result;
+    } catch (error) {
+      if (requiresInteraction(error)) {
+        return null;
+      }
+      throw normalizeMsalError(error);
+    }
+  };
+
+  let result = null;
+  if (!forceLogin) {
+    result = await trySilent();
+    if (result?.accessToken) {
+      return result.accessToken;
+    }
+  }
+
+  try {
+    const interactiveResult = await msalInstance.acquireTokenPopup({
+      scopes: SCOPES,
+      prompt: activeAccount ? 'login' : 'select_account',
+      ...(activeAccount ? { account: activeAccount } : {})
+    });
+    if (interactiveResult?.account) {
+      activeAccount = interactiveResult.account;
+      msalInstance.setActiveAccount(interactiveResult.account);
+    }
+    return interactiveResult?.accessToken || null;
+  } catch (error) {
+    throw normalizeMsalError(error);
+  }
+}
+
+export async function initOneDrive(options = {}) {
+  if (accessToken && !options.forceLogin) {
+    return accessToken;
+  }
+  accessToken = await acquireAccessToken({ forceLogin: options.forceLogin });
   return accessToken;
 }
 
+async function fetchWithOneDriveToken(url, { method = 'GET', headers = {}, body } = {}) {
+  let token = await initOneDrive();
+  if (!token) return null;
+
+  const performFetch = async () =>
+    fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...headers
+      },
+      body
+    });
+
+  let response = await performFetch();
+  if (response.status === 401) {
+    accessToken = null;
+    token = await initOneDrive({ forceLogin: true });
+    if (!token) return response;
+    response = await performFetch();
+  }
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    const errorMessage = errorText ? `${response.status}: ${errorText}` : `${response.status}`;
+    throw new Error(`OneDrive request failed (${errorMessage})`);
+  }
+  return response;
+}
+
 export async function exportTransactionsToOneDrive(list) {
-  const token = await initOneDrive();
-  if (!token) return;
   const csv = transactionsToCsv(list);
-  await fetch(`${GRAPH_BASE}/v1.0/me/drive/root:/inventory_backup.csv:/content`, {
+  await fetchWithOneDriveToken(`${GRAPH_BASE}/v1.0/me/drive/root:/inventory_backup.csv:/content`, {
     method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'text/csv'
-    },
+    headers: { 'Content-Type': 'text/csv' },
     body: csv
   });
 }
 
 export async function importTransactionsFromOneDrive() {
-  const token = await initOneDrive();
-  if (!token) return null;
   try {
-    const res = await fetch(`${GRAPH_BASE}/v1.0/me/drive/root:/inventory_backup.csv:/content`, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
-    if (!res.ok) return null;
+    const res = await fetchWithOneDriveToken(
+      `${GRAPH_BASE}/v1.0/me/drive/root:/inventory_backup.csv:/content`
+    );
+    if (!res) return null;
     const text = await res.text();
     return transactionsFromCsv(text);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Harden the OneDrive integration to normalize scopes, reuse cached accounts, and surface actionable guidance when Azure requires confidential client credentials.
- Retry OneDrive API calls with refreshed tokens and show detailed OneDrive error messages in the manual import/export prompts.

## Testing
- pnpm test -- --runTestsByPath tests/InventoryTab.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d562adc9408329ad54058509c18df8