### PR TITLE
Handle unresolved OneDrive authority placeholders

### DIFF
--- a/src/oneDrive.js
+++ b/src/oneDrive.js
@@ -1,23 +1,47 @@
 import { transactionsToCsv, transactionsFromCsv } from './utils/csvUtils';
 
-const CLIENT_ID =
-  typeof window !== 'undefined' && window.ONEDRIVE_CLIENT_ID && window.ONEDRIVE_CLIENT_ID !== 'undefined'
-    ? window.ONEDRIVE_CLIENT_ID
-    : '';
-const RAW_SCOPES =
-  typeof window !== 'undefined' && window.ONEDRIVE_SCOPES && window.ONEDRIVE_SCOPES !== 'undefined'
-    ? window.ONEDRIVE_SCOPES
-    : '';
+function readImportMetaEnv(key) {
+  try {
+    if (typeof import.meta !== 'undefined' && import.meta.env) {
+      return import.meta.env[key];
+    }
+  } catch (error) {
+    console.warn('Unable to read import.meta.env', error);
+  }
+  return undefined;
+}
+
+function resolveWindowString(key, { fallback, allowPercentPlaceholders = false } = {}) {
+  let resolvedFallback = fallback;
+  if (typeof resolvedFallback === 'undefined') {
+    const envKey = `VITE_${key}`;
+    const envValue = readImportMetaEnv(envKey);
+    if (typeof envValue === 'string' && envValue.trim()) {
+      resolvedFallback = envValue.trim();
+    } else {
+      resolvedFallback = '';
+    }
+  }
+
+  if (typeof window === 'undefined') return resolvedFallback;
+  const value = window[key];
+  if (typeof value !== 'string') return resolvedFallback;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'undefined') return resolvedFallback;
+  if (!allowPercentPlaceholders && /^%[A-Z0-9_]+%$/i.test(trimmed)) {
+    return resolvedFallback;
+  }
+  return trimmed;
+}
+
+const CLIENT_ID = resolveWindowString('ONEDRIVE_CLIENT_ID');
+const RAW_SCOPES = resolveWindowString('ONEDRIVE_SCOPES', { allowPercentPlaceholders: true });
 const DEFAULT_SCOPES = ['Files.ReadWrite'];
 const BASE_OPENID_SCOPES = ['openid', 'profile'];
 const AUTHORITY =
-  typeof window !== 'undefined' && window.ONEDRIVE_AUTHORITY && window.ONEDRIVE_AUTHORITY !== 'undefined'
-    ? window.ONEDRIVE_AUTHORITY
-    : 'https://login.microsoftonline.com/common';
+  resolveWindowString('ONEDRIVE_AUTHORITY') || 'https://login.microsoftonline.com/common';
 const GRAPH_BASE =
-  typeof window !== 'undefined' && window.ONEDRIVE_GRAPH_BASE && window.ONEDRIVE_GRAPH_BASE !== 'undefined'
-    ? window.ONEDRIVE_GRAPH_BASE.replace(/\/$/, '')
-    : 'https://graph.microsoft.com';
+  (resolveWindowString('ONEDRIVE_GRAPH_BASE') || 'https://graph.microsoft.com').replace(/\/$/, '');
 let msalInstance = null;
 let accessToken = null;
 let msalLoaded = false;


### PR DESCRIPTION
## Summary
- add a helper to sanitize window-provided OneDrive environment strings
- fall back to default authority/graph values when placeholders are still present
- allow bundled Vite environment values to satisfy OneDrive config when window placeholders remain

## Testing
- pnpm lint *(fails with existing warnings about exhaustive-deps and unused eslint-disable)*

------
https://chatgpt.com/codex/tasks/task_e_68d5715693a88329ab107f40df0191d8