### PR TITLE
Handle missing OneDrive configuration gracefully

### DIFF
--- a/src/components/DataDropdown.jsx
+++ b/src/components/DataDropdown.jsx
@@ -17,7 +17,8 @@ export default function DataDropdown({
   onSelectChange,
   autoSaveEnabled,
   onToggleAutoSave,
-  autoSaveState
+  autoSaveState,
+  oneDriveAvailable = false
 }) {
   const ref = useRef();
   useClickOutside(ref, onClose);
@@ -70,10 +71,14 @@ export default function DataDropdown({
       import: handleDriveImport,
       export: handleDriveExport
     },
-    oneDrive: {
-      import: handleOneDriveImport,
-      export: handleOneDriveExport
-    },
+    ...(oneDriveAvailable
+      ? {
+          oneDrive: {
+            import: handleOneDriveImport,
+            export: handleOneDriveExport
+          }
+        }
+      : {}),
     icloudDrive: {
       import: handleICloudImport,
       export: handleICloudExport
@@ -81,8 +86,12 @@ export default function DataDropdown({
   };
 
   const handleSelectChange = event => {
+    const value = event.target.value;
+    if (value === 'oneDrive' && !oneDriveAvailable) {
+      return;
+    }
     if (typeof onSelectChange === 'function') {
-      onSelectChange(event.target.value);
+      onSelectChange(value);
     }
   };
 
@@ -98,7 +107,7 @@ export default function DataDropdown({
   const providerLabels = {
     csv: 'CSV',
     googleDrive: 'Google Drive',
-    oneDrive: 'OneDrive',
+    ...(oneDriveAvailable ? { oneDrive: 'OneDrive' } : {}),
     icloudDrive: 'iCloudDrive'
   };
   const providerLabel = providerLabels?.[autoSaveState?.provider] || '';
@@ -165,7 +174,7 @@ export default function DataDropdown({
         >
           <option value="csv">CSV</option>
           <option value="googleDrive">Google Drive</option>
-          <option value="oneDrive">OneDrive</option>
+          {oneDriveAvailable && <option value="oneDrive">OneDrive</option>}
           <option value="icloudDrive">iCloudDrive</option>
         </select>
       </div>

--- a/src/oneDrive.js
+++ b/src/oneDrive.js
@@ -25,6 +25,10 @@ let accessToken = null;
 let msalLoaded = false;
 let activeAccount = null;
 
+export function isOneDriveConfigured() {
+  return Boolean(CLIENT_ID);
+}
+
 const SCOPES = (() => {
   const input = typeof RAW_SCOPES === 'string' ? RAW_SCOPES : '';
   const requested = input


### PR DESCRIPTION
## Summary
- add an exported helper to detect OneDrive configuration
- hide OneDrive options and guard handlers when the client ID is missing
- ensure auto-save falls back and warns if OneDrive is unavailable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dd3856548329b67c4b0bdae31773