### PR TITLE
Ensure calendar filter test awaits UI updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,6 +50,21 @@ function calcIncomeGoalInfo(dividend, price, goal, freq = 12, lang = 'zh') {
     : `\n月報酬${goal.toLocaleString()}需: ${lotsNeeded}張\n成本: ${cost}元`;
 }
 
+const isChineseLanguage = (lang) => lang && lang.toLowerCase().startsWith('zh');
+
+const getInitialLanguage = () => {
+  if (typeof window === 'undefined') return 'zh';
+
+  const stored = window.localStorage?.getItem('lang');
+  if (stored) return stored;
+
+  const browserLanguages = window.navigator?.languages?.length
+    ? window.navigator.languages
+    : [window.navigator?.language];
+
+  return browserLanguages?.some(isChineseLanguage) ? 'zh' : 'en';
+};
+
 function App() {
   // Tab state
   const [tab, setTab] = useState('home');
@@ -103,7 +118,7 @@ function App() {
 
 
   // Language
-  const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'zh');
+  const [lang, setLang] = useState(getInitialLanguage);
   useEffect(() => {
     localStorage.setItem('lang', lang);
   }, [lang]);

--- a/tests/AppCalendarFilter.test.jsx
+++ b/tests/AppCalendarFilter.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 // Mock asset imports used by App
 jest.mock('../src/assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
 jest.mock('../src/assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
@@ -18,9 +18,15 @@ beforeAll(() => {
 });
 
 test('calendar defaults to showing both ex and payment events', async () => {
-  render(<App />);
+  localStorage.clear();
+  localStorage.setItem('lang', 'zh');
+  await act(async () => {
+    render(<App />);
+  });
   const dividendTab = screen.getByRole('button', { name: 'ETF 配息查詢' });
-  fireEvent.click(dividendTab);
+  await act(async () => {
+    fireEvent.click(dividendTab);
+  });
   const bothBtn = await screen.findByRole('button', { name: '除息/發放日' });
   expect(bothBtn).toHaveClass('btn-selected');
 });

--- a/tests/AppCalendarVisibility.test.jsx
+++ b/tests/AppCalendarVisibility.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 // Mock asset imports used by App
 jest.mock('../src/assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
 jest.mock('../src/assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
@@ -19,15 +19,35 @@ beforeAll(() => {
 
 test('App remembers calendar visibility', async () => {
   localStorage.clear();
-  const { unmount } = render(<App />);
-  const dividendTab = screen.getByRole('button', { name: 'ETF 配息查詢' });
-  fireEvent.click(dividendTab);
+  localStorage.setItem('lang', 'zh');
+  let unmount;
+  await act(async () => {
+    ({ unmount } = render(<App />));
+  });
+
+  const dividendTab = await screen.findByRole('button', { name: 'ETF 配息查詢' });
+  await act(async () => {
+    fireEvent.click(dividendTab);
+  });
+
   const hideBtn = await screen.findByRole('button', { name: '隱藏月曆' });
-  fireEvent.click(hideBtn);
-  unmount();
-  render(<App />);
-  const dividendTab2 = screen.getByRole('button', { name: 'ETF 配息查詢' });
-  fireEvent.click(dividendTab2);
+  await act(async () => {
+    fireEvent.click(hideBtn);
+  });
+
+  await act(async () => {
+    unmount();
+  });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const dividendTab2 = await screen.findByRole('button', { name: 'ETF 配息查詢' });
+  await act(async () => {
+    fireEvent.click(dividendTab2);
+  });
+
   const showBtn = await screen.findByRole('button', { name: '顯示月曆' });
   expect(showBtn).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- wrap the calendar visibility test interactions in `act` to avoid warnings from asynchronous updates
- seed the stored language preference and await element queries to keep assertions stable after the locale detection change
- ensure the calendar filter test awaits its render interactions and seeds the language preference so the Chinese labels remain accessible

## Testing
- npm test -- AppCalendarFilter

------
https://chatgpt.com/codex/tasks/task_e_68d7e63ef8f483298cd5f83898ae7af8