### PR TITLE
Add monthly dividend cost summary to user overview

### DIFF
--- a/src/UserDividendsTab.jsx
+++ b/src/UserDividendsTab.jsx
@@ -472,8 +472,8 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                     ) : (
                         <>
                             <tr style={{ background: '#d0ebff', fontWeight: 'bold' }}>
-                                <td>{lang === 'en' ? 'Monthly Dividend Cost' : '月配息成本'}</td>
-                                <td>{displayCostGrandTotal > 0 ? Math.round(displayCostGrandTotal).toLocaleString() : ''}</td>
+                                <td>{lang === 'en' ? 'Dividend Cost' : '配息成本'}</td>
+                                <td></td>
                                 {displayCostPerMonth.map((total, idx) => (
                                     <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>
                                         {total > 0 ? Math.round(total).toLocaleString() : ''}


### PR DESCRIPTION
## Summary
- compute average cost basis per stock before the ex-date and include it in the dividend table data
- display a monthly dividend cost row ahead of the monthly totals in the user dividend overview

## Testing
- npm test -- UserDividendsTab

------
https://chatgpt.com/codex/tasks/task_e_68da78bb0a608329bb26d427d63450b0