### PR TITLE
Ensure dividend table falls back to latest available year

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -204,7 +204,13 @@ function App() {
         const availableYearSet = new Set(filteredArr.map(item => new Date(item.dividend_date).getFullYear()));
         const yearList = Array.from(new Set([...ALLOWED_YEARS, ...availableYearSet])).sort((a, b) => b - a);
         setYears(yearList);
-        if (!yearList.includes(selectedYear)) setSelectedYear(yearList[0]);
+
+        if (availableYearSet.size > 0 && !availableYearSet.has(selectedYear)) {
+          const sortedAvailableYears = Array.from(availableYearSet).sort((a, b) => b - a);
+          setSelectedYear(sortedAvailableYears[0]);
+        } else if (!yearList.includes(selectedYear)) {
+          setSelectedYear(yearList[0]);
+        }
       } catch (error) {
         setError(error);
       } finally {

--- a/tests/AppYearSelection.test.jsx
+++ b/tests/AppYearSelection.test.jsx
@@ -1,0 +1,86 @@
+/* eslint-env jest */
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+
+jest.mock('../src/assets/conceptB-ETF-Life-dark.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+jest.mock('../src/assets/conceptB-ETF-Life-light.svg', () => 'data:image/svg+xml;base64,PHN2Zy8+');
+
+const mockFetchWithCache = jest.fn();
+
+jest.mock('../src/api', () => ({
+  fetchWithCache: (...args) => mockFetchWithCache(...args),
+  clearCache: jest.fn()
+}));
+
+const mockFetchDividendsByYears = jest.fn();
+
+jest.mock('../src/dividendApi', () => ({
+  fetchDividendsByYears: (...args) => mockFetchDividendsByYears(...args),
+  clearDividendsCache: jest.fn()
+}));
+
+jest.mock('../src/config', () => ({ API_HOST: '' }));
+
+import App from '../src/App';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem('lang', 'zh');
+  mockFetchWithCache.mockReset();
+  mockFetchDividendsByYears.mockReset();
+  global.fetch = jest.fn(() => Promise.resolve({}));
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+test('falls back to the latest available year when current year has no data', async () => {
+  const currentYear = new Date().getFullYear();
+  const previousYear = currentYear - 1;
+
+  mockFetchDividendsByYears.mockResolvedValue({
+    data: [
+      {
+        stock_id: '0050',
+        stock_name: '台灣50',
+        dividend_date: `${previousYear}-05-01`,
+        payment_date: `${previousYear}-06-01`,
+        dividend: '1.23',
+        dividend_yield: '4.56',
+        last_close_price: '100'
+      }
+    ],
+    meta: [
+      { year: previousYear, cacheStatus: 'cached', timestamp: '2024-06-01T00:00:00Z' }
+    ]
+  });
+
+  mockFetchWithCache.mockImplementation((url) => {
+    if (url.includes('/get_stock_list')) {
+      return Promise.resolve({ data: [] });
+    }
+    if (url.includes('/site_stats')) {
+      return Promise.resolve({ data: { milestones: [], latest: [], tip: '' } });
+    }
+    return Promise.resolve({ data: [] });
+  });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const dividendTab = await screen.findByRole('button', { name: 'ETF 配息查詢' });
+
+  await act(async () => {
+    fireEvent.click(dividendTab);
+  });
+
+  const [yearSelect] = await screen.findAllByRole('combobox');
+
+  await waitFor(() => {
+    expect(yearSelect.value).toBe(String(previousYear));
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the dividend tab switches to the latest year that actually has data so the stock table populates
- add a regression test covering the year fallback logic when the current year is empty

## Testing
- pnpm test -- AppYearSelection

------
https://chatgpt.com/codex/tasks/task_e_68dd6a40c78083299e677319b57bb085