### PR TITLE
Add Budget Life frontend scaffold

### DIFF
--- a/apps/budget-life/README.md
+++ b/apps/budget-life/README.md
@@ -1,0 +1,16 @@
+# Budget Life
+
+Budget Life 是 ETF Life 的姊妹專案，專注於日常支出追蹤與預算規劃。此資料夾內包含一個使用 React + Vite 建立的全新前端專案雛形，方便後續擴充。
+
+## 可用指令
+
+在專案根目錄安裝依賴後，可於此資料夾執行以下指令：
+
+```bash
+pnpm install
+pnpm dev
+pnpm build
+pnpm preview
+```
+
+> 若你已在 monorepo 層使用 pnpm workspace 管理套件，記得將 `apps/budget-life` 加入 `pnpm-workspace.yaml`，即可共用頂層依賴並快速啟動開發環境。

--- a/apps/budget-life/index.html
+++ b/apps/budget-life/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Budget Life</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/apps/budget-life/package.json
+++ b/apps/budget-life/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "budget-life",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.6.0",
+    "eslint": "^9.30.1",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "vite": "^7.0.4"
+  }
+}

--- a/apps/budget-life/src/App.css
+++ b/apps/budget-life/src/App.css
@@ -1,0 +1,156 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 0% 0%, #e0f2fe, transparent 55%),
+    radial-gradient(circle at 100% 0%, #fce7f3, transparent 55%),
+    #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3rem);
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  margin: 0 auto;
+  max-width: 40ch;
+  color: #475569;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.filter-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #1e293b;
+}
+
+.filter-select {
+  appearance: none;
+  background-color: #fff;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #0f172a;
+  box-shadow: 0 10px 25px -12px rgba(30, 64, 175, 0.35);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 16px 30px -18px rgba(37, 99, 235, 0.5);
+}
+
+.summary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(139, 92, 246, 0.1));
+  border-radius: 1.25rem;
+  padding: 2rem;
+  margin-bottom: 2.5rem;
+  text-align: center;
+}
+
+.summary h2 {
+  margin-top: 0;
+  color: #1d4ed8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.summary-total {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  font-weight: 700;
+  margin: 0;
+  color: #0f172a;
+}
+
+.transactions table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 0.75rem;
+}
+
+.transactions thead th {
+  text-align: left;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+  padding: 0 1.5rem 0.75rem;
+}
+
+.transactions tbody tr {
+  background-color: #fff;
+  box-shadow: 0 15px 30px -18px rgba(15, 23, 42, 0.3);
+  border-radius: 1rem;
+}
+
+.transactions tbody td {
+  padding: 1.25rem 1.5rem;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.transactions tbody tr td:first-child {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.transactions tbody tr td:last-child {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (min-width: 640px) {
+  .filters {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .filter-label {
+    margin: 0;
+  }
+
+  .filter-select {
+    max-width: 220px;
+  }
+}

--- a/apps/budget-life/src/App.jsx
+++ b/apps/budget-life/src/App.jsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react';
+
+const mockCategories = [
+  { id: 'housing', label: 'Housing' },
+  { id: 'food', label: 'Food & Dining' },
+  { id: 'transport', label: 'Transportation' },
+  { id: 'leisure', label: 'Leisure' },
+  { id: 'savings', label: 'Savings' },
+];
+
+const mockTransactions = [
+  { id: 1, category: 'housing', description: 'Rent', amount: 1200 },
+  { id: 2, category: 'food', description: 'Groceries', amount: 320 },
+  { id: 3, category: 'transport', description: 'Metro card', amount: 75 },
+  { id: 4, category: 'leisure', description: 'Streaming subscriptions', amount: 45 },
+  { id: 5, category: 'savings', description: 'Emergency fund', amount: 200 },
+];
+
+export default function App() {
+  const [selectedCategory, setSelectedCategory] = useState('all');
+
+  const filteredTransactions = useMemo(() => {
+    if (selectedCategory === 'all') {
+      return mockTransactions;
+    }
+
+    return mockTransactions.filter((transaction) => transaction.category === selectedCategory);
+  }, [selectedCategory]);
+
+  const total = filteredTransactions.reduce((sum, transaction) => sum + transaction.amount, 0);
+
+  return (
+    <div className="app">
+      <header className="hero">
+        <h1>Budget Life</h1>
+        <p className="tagline">Track day-to-day spending and stay aligned with long-term goals.</p>
+      </header>
+
+      <section className="filters" aria-label="transaction filters">
+        <label className="filter-label" htmlFor="category">
+          Category
+        </label>
+        <select
+          id="category"
+          className="filter-select"
+          value={selectedCategory}
+          onChange={(event) => setSelectedCategory(event.target.value)}
+        >
+          <option value="all">All categories</option>
+          {mockCategories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.label}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      <section className="summary" aria-live="polite">
+        <h2>Monthly summary</h2>
+        <p className="summary-total">
+          <span aria-label="currency">$</span>
+          {total.toLocaleString()}
+        </p>
+      </section>
+
+      <section className="transactions" aria-label="transaction list">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Description</th>
+              <th scope="col">Category</th>
+              <th scope="col" className="numeric">
+                Amount
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredTransactions.map((transaction) => (
+              <tr key={transaction.id}>
+                <td>{transaction.description}</td>
+                <td>{mockCategories.find((category) => category.id === transaction.category)?.label}</td>
+                <td className="numeric">${transaction.amount.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/apps/budget-life/src/main.jsx
+++ b/apps/budget-life/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/budget-life/vite.config.js
+++ b/apps/budget-life/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5174,
+  },
+});


### PR DESCRIPTION
## Summary
- add a new apps/budget-life workspace with a standalone Vite + React scaffold
- implement a mock budgeting dashboard UI with filtering and summary styling
- document local commands for developing the Budget Life project

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7ade7a7c8329a7bbf7cb31fa5a0d