### PR TITLE
Adjust cache lifetimes for twice-daily data updates

### DIFF
--- a/apps/etf-life/src/HomeTab.jsx
+++ b/apps/etf-life/src/HomeTab.jsx
@@ -30,7 +30,7 @@ export default function HomeTab() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchWithCache(`${API_HOST}/site_stats?en=${lang === 'en'}`, 4 * 60 * 60 * 1000)
+    fetchWithCache(`${API_HOST}/site_stats?en=${lang === 'en'}`, 10 * 60 * 60 * 1000)
       .then(({ data }) => {
         if (!cancelled) {
           setStats({

--- a/apps/etf-life/src/StockDetail.jsx
+++ b/apps/etf-life/src/StockDetail.jsx
@@ -30,7 +30,7 @@ export default function StockDetail({ stockId }) {
             ? data.items
             : [];
     },
-    staleTime: 2 * 60 * 60 * 1000,
+    staleTime: 10 * 60 * 60 * 1000,
   });
 
   const { data: dividendList = [], isLoading: dividendLoading } = useQuery({
@@ -58,7 +58,7 @@ export default function StockDetail({ stockId }) {
       const data = fulfilledResults.flatMap(result => result.value);
       return data.filter(item => ALLOWED_YEARS.includes(new Date(item.dividend_date).getFullYear()));
     },
-    staleTime: 2 * 60 * 60 * 1000,
+    staleTime: 10 * 60 * 60 * 1000,
   });
 
   const { data: returns = {}, isLoading: returnsLoading } = useQuery({
@@ -67,7 +67,7 @@ export default function StockDetail({ stockId }) {
       const res = await fetch(`${API_HOST}/get_returns?stock_id=${stockId}`);
       return await res.json();
     },
-    staleTime: 2 * 60 * 60 * 1000,
+    staleTime: 10 * 60 * 60 * 1000,
   });
 
   const stock = useMemo(() => {

--- a/apps/etf-life/src/api.js
+++ b/apps/etf-life/src/api.js
@@ -1,4 +1,4 @@
-export async function fetchWithCache(url, maxAge = 2 * 60 * 60 * 1000) {
+export async function fetchWithCache(url, maxAge = 10 * 60 * 60 * 1000) {
   // maxAge controls how long to reuse cached data before revalidating
   const cacheKey = `cache:data:${url}`;
   const metaKey = `cache:meta:${url}`;

--- a/apps/etf-life/tests/api.test.js
+++ b/apps/etf-life/tests/api.test.js
@@ -31,7 +31,7 @@ describe('fetchWithCache', () => {
   test('fetches new data when cache expired', async () => {
     jest.useFakeTimers();
     const oldTimestamp = new Date('2024-01-01T00:00:00Z').toISOString();
-    jest.setSystemTime(new Date('2024-01-01T02:01:00Z'));
+    jest.setSystemTime(new Date('2024-01-01T10:01:00Z'));
     localStorage.setItem(cacheKey, JSON.stringify({ value: 1 }));
     localStorage.setItem(metaKey, JSON.stringify({ timestamp: oldTimestamp, etag: 'old' }));
 
@@ -48,13 +48,13 @@ describe('fetchWithCache', () => {
     expect(globalThis.fetch.mock.calls[0][1]).toEqual({ headers: {} });
     expect(result.data).toEqual(newData);
     expect(result.cacheStatus).toBe('fresh');
-    expect(result.timestamp).toBe(new Date('2024-01-01T02:01:00Z').toISOString());
+    expect(result.timestamp).toBe(new Date('2024-01-01T10:01:00Z').toISOString());
   });
 
   test('falls back to stale cache on fetch error', async () => {
     jest.useFakeTimers();
     const timestamp = new Date('2024-01-01T00:00:00Z').toISOString();
-    jest.setSystemTime(new Date('2024-01-01T03:00:00Z'));
+    jest.setSystemTime(new Date('2024-01-01T10:01:00Z'));
     localStorage.setItem(cacheKey, JSON.stringify({ value: 1 }));
     localStorage.setItem(metaKey, JSON.stringify({ timestamp }));
 


### PR DESCRIPTION
## Summary
- extend the default fetchWithCache maxAge to 10 hours to match twice-daily refreshes
- align StockDetail query staleTime values with the new cache window and reuse it for the home stats fetch
- update fetchWithCache unit tests to reflect the longer cache duration

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68df233154c08329be564ac3c1f6c63e