### PR TITLE
Sanitize dividend aggregation before displaying monthly data

### DIFF
--- a/apps/etf-life/src/components/StockTable.jsx
+++ b/apps/etf-life/src/components/StockTable.jsx
@@ -129,15 +129,31 @@ export default function StockTable({
           const perYield = cell.perYield || 0;
           const rawDividend = Number(cell.dividend);
           const rawYield = Number(cell.dividend_yield);
-          const isDividendValid = Number.isFinite(rawDividend);
-          const isYieldValid = Number.isFinite(rawYield);
+          const hasValidDividend = Boolean(cell.hasValidDividend);
+          const hasValidYield = Boolean(cell.hasValidYield);
+          const isDividendValid = hasValidDividend && Number.isFinite(rawDividend);
+          const isYieldValid = hasValidYield && Number.isFinite(rawYield);
+          const hasPendingDividend = Boolean(cell.hasPendingDividend);
+          const hasPendingYield = Boolean(cell.hasPendingYield);
           const pendingText = lang === 'zh' ? '待確認' : 'Pending';
-          const displayDividend = isDividendValid ? rawDividend.toFixed(3) : pendingText;
-          const displayYield = isYieldValid ? `${rawYield.toFixed(1)}%` : pendingText;
+          const displayDividend = isDividendValid
+            ? rawDividend.toFixed(3)
+            : hasPendingDividend
+              ? pendingText
+              : '';
+          const displayYield = isYieldValid
+            ? `${rawYield.toFixed(1)}%`
+            : (hasPendingYield || hasPendingDividend)
+              ? pendingText
+              : '';
           const displayVal = showDividendYield ? displayYield : displayDividend;
           const price = latestPrice[stock.stock_id]?.price;
           const extraInfo = getIncomeGoalInfo(isDividendValid ? rawDividend : 0, price, monthlyIncomeGoal, freq || 12);
-          const tooltipYield = isYieldValid ? `${rawYield.toFixed(1)}%` : pendingText;
+          const tooltipYield = isYieldValid
+            ? `${rawYield.toFixed(1)}%`
+            : (hasPendingYield || hasPendingDividend)
+              ? pendingText
+              : '';
           const lastClose = cell.last_close_price ?? '-';
           const dividendDate = cell.dividend_date || '-';
           const paymentDate = cell.payment_date || '-';


### PR DESCRIPTION
## Summary
- guard the dividend aggregation against non-numeric placeholder values so valid updates are preserved
- track pending dividend and yield states per month and surface them without overwriting confirmed numbers in the stock table
- normalize stored dividend totals, yields, and metadata so stale NaN or string payloads from cached entries cannot leak into the monthly summary or tooltips

## Testing
- pnpm --filter etf-life lint


------
https://chatgpt.com/codex/tasks/task_e_68df3dbf8e988329b2ae8ac0a2ea4347