### PR TITLE
Fix stale dividend cache on mobile clients

### DIFF
--- a/apps/etf-life/src/api.js
+++ b/apps/etf-life/src/api.js
@@ -1,22 +1,23 @@
 export async function fetchWithCache(url, maxAge = 10 * 60 * 60 * 1000) {
-  // maxAge controls how long to reuse cached data before revalidating
+  // maxAge controls how long cached data is considered "fresh" before we label it stale.
   const cacheKey = `cache:data:${url}`;
   const metaKey = `cache:meta:${url}`;
   const headers = {};
   let meta;
   let age = Infinity;
+  let cachedTimestamp = null;
+  let cachedData;
+  let hasCachedData = false;
 
   try {
     const metaRaw = localStorage.getItem(metaKey);
     if (metaRaw) {
       meta = JSON.parse(metaRaw);
-      if (meta.timestamp) {
-        age = Date.now() - new Date(meta.timestamp).getTime();
-        if (age < maxAge) {
-          const cached = localStorage.getItem(cacheKey);
-          if (cached) {
-            return { data: JSON.parse(cached), cacheStatus: 'cached', timestamp: meta.timestamp };
-          }
+      if (meta?.timestamp) {
+        cachedTimestamp = meta.timestamp;
+        const cachedTime = new Date(meta.timestamp);
+        if (!Number.isNaN(cachedTime.getTime())) {
+          age = Date.now() - cachedTime.getTime();
         }
       }
     }
@@ -24,9 +25,22 @@ export async function fetchWithCache(url, maxAge = 10 * 60 * 60 * 1000) {
     // ignore parse errors
   }
 
-  if (meta?.etag && age < maxAge) {
+  try {
+    const raw = localStorage.getItem(cacheKey);
+    if (raw !== null) {
+      cachedData = JSON.parse(raw);
+      hasCachedData = true;
+    }
+  } catch {
+    // ignore storage or parse errors
+    cachedData = undefined;
+    hasCachedData = false;
+  }
+
+  const hasFreshCache = hasCachedData && age < maxAge;
+  if (meta?.etag) {
     headers['If-None-Match'] = meta.etag;
-  } else if (meta?.lastModified && age < maxAge) {
+  } else if (meta?.lastModified) {
     headers['If-Modified-Since'] = meta.lastModified;
   }
 
@@ -34,9 +48,12 @@ export async function fetchWithCache(url, maxAge = 10 * 60 * 60 * 1000) {
   try {
     response = await fetch(url, { headers });
   } catch (err) {
-    const cached = localStorage.getItem(cacheKey);
-    if (cached) {
-      return { data: JSON.parse(cached), cacheStatus: 'stale', timestamp: meta?.timestamp || null };
+    if (hasCachedData) {
+      return {
+        data: cachedData,
+        cacheStatus: hasFreshCache ? 'cached' : 'stale',
+        timestamp: cachedTimestamp
+      };
     }
     throw err;
   }
@@ -56,27 +73,26 @@ export async function fetchWithCache(url, maxAge = 10 * 60 * 60 * 1000) {
   }
 
   if (response.status === 304) {
-    const cached = localStorage.getItem(cacheKey);
-    if (cached) {
+    if (hasCachedData) {
       const etag = response.headers.get('ETag') || meta?.etag || null;
       const lastModified = response.headers.get('Last-Modified') || meta?.lastModified || null;
       const timestamp = new Date().toISOString();
       try {
-        localStorage.setItem(
-          metaKey,
-          JSON.stringify({ etag, lastModified, timestamp })
-        );
+        localStorage.setItem(metaKey, JSON.stringify({ etag, lastModified, timestamp }));
       } catch {
         // ignore write errors
       }
-      return { data: JSON.parse(cached), cacheStatus: 'cached', timestamp };
+      return { data: cachedData, cacheStatus: 'cached', timestamp };
     }
     throw new Error('No cached data available');
   }
 
-  const cached = localStorage.getItem(cacheKey);
-  if (cached) {
-    return { data: JSON.parse(cached), cacheStatus: 'stale', timestamp: meta?.timestamp || null };
+  if (hasCachedData) {
+    return {
+      data: cachedData,
+      cacheStatus: hasFreshCache ? 'cached' : 'stale',
+      timestamp: cachedTimestamp
+    };
   }
 
   throw new Error(`HTTP error! status: ${response.status}`);

--- a/apps/etf-life/tests/api.test.js
+++ b/apps/etf-life/tests/api.test.js
@@ -14,18 +14,26 @@ describe('fetchWithCache', () => {
     jest.resetAllMocks();
   });
 
-  test('returns cached data when not expired', async () => {
+  test('revalidates cached data when not expired', async () => {
     jest.useFakeTimers();
     const timestamp = new Date('2024-01-01T00:00:00Z').toISOString();
     jest.setSystemTime(new Date('2024-01-01T01:00:00Z'));
     localStorage.setItem(cacheKey, JSON.stringify({ value: 1 }));
-    localStorage.setItem(metaKey, JSON.stringify({ timestamp }));
-    globalThis.fetch = jest.fn();
+    localStorage.setItem(metaKey, JSON.stringify({ timestamp, etag: 'etag-1' }));
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      status: 304,
+      headers: { get: () => null }
+    });
 
     const result = await fetchWithCache(URL);
 
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    expect(result).toEqual({ data: { value: 1 }, cacheStatus: 'cached', timestamp });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(URL, {
+      headers: { 'If-None-Match': 'etag-1' }
+    });
+    expect(result.data).toEqual({ value: 1 });
+    expect(result.cacheStatus).toBe('cached');
+    expect(result.timestamp).toBe(new Date('2024-01-01T01:00:00Z').toISOString());
   });
 
   test('fetches new data when cache expired', async () => {
@@ -45,7 +53,9 @@ describe('fetchWithCache', () => {
     const result = await fetchWithCache(URL);
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch.mock.calls[0][1]).toEqual({ headers: {} });
+    expect(globalThis.fetch.mock.calls[0][1]).toEqual({
+      headers: { 'If-None-Match': 'old' }
+    });
     expect(result.data).toEqual(newData);
     expect(result.cacheStatus).toBe('fresh');
     expect(result.timestamp).toBe(new Date('2024-01-01T10:01:00Z').toISOString());


### PR DESCRIPTION
## Summary
- update `fetchWithCache` so we always revalidate with the API before serving cached dividend data
- reuse parsed cached payloads and return consistent cache status metadata when falling back to stored responses

## Testing
- pnpm --filter etf-life lint
- pnpm --filter etf-life test -- --runTestsByPath (fails: no matching tests)


------
https://chatgpt.com/codex/tasks/task_e_68df4dda213083298a0823db612bbd04