### PR TITLE
feat: show dividend tips on mobile

### DIFF
--- a/apps/etf-life/src/App.css
+++ b/apps/etf-life/src/App.css
@@ -771,3 +771,24 @@ button:active {
 .btn-unselected {
   opacity: 0.6;
 }
+
+.tooltip-text {
+  position: relative;
+}
+
+.tooltip-text .tooltip-inline {
+  display: block;
+  position: relative;
+  margin-top: 6px;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-line;
+  z-index: 1;
+  max-width: min(280px, calc(100vw - 48px));
+  word-break: break-word;
+}

--- a/apps/etf-life/src/UserDividendsTab.jsx
+++ b/apps/etf-life/src/UserDividendsTab.jsx
@@ -5,6 +5,7 @@ import { HOST_URL, API_HOST } from './config';
 import { useLanguage } from './i18n';
 import usePreserveScroll from './hooks/usePreserveScroll';
 import { fetchWithCache } from './api';
+import TooltipText from './components/TooltipText';
 
 const MONTH_COL_WIDTH = 80;
 function getTransactionHistory() {
@@ -509,12 +510,12 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                         <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>
                                             {total > 0 ? (
                                                 hasTooltip ? (
-                                                    <span
-                                                        title={tooltip}
-                                                        style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
+                                                    <TooltipText
+                                                        tooltip={tooltip}
+                                                        style={{ borderBottom: '1px dotted #777' }}
                                                     >
                                                         {Math.round(total).toLocaleString()}
-                                                    </span>
+                                                    </TooltipText>
                                                 ) : Math.round(total).toLocaleString()
                                             ) : ''}
                                         </td>
@@ -525,14 +526,14 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                 <td>{lang === 'en' ? 'Monthly Total' : '月合計'}</td>
                                 <td>
                                     {displayGrandTotal > 0 ? (
-                                        <span
-                                            title={lang === 'en'
+                                        <TooltipText
+                                            tooltip={lang === 'en'
                                                 ? `Average per month: ${Math.round(displayAvgPerMonth).toLocaleString()}`
                                                 : `每月平均領取: ${Math.round(displayAvgPerMonth).toLocaleString()}`}
-                                            style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
+                                            style={{ borderBottom: '1px dotted #777' }}
                                         >
                                             {Math.round(displayGrandTotal).toLocaleString()}
-                                        </span>
+                                        </TooltipText>
                                     ) : ''}
                                 </td>
                                 {displayTotalsPerMonth.map((total, idx) => (
@@ -553,14 +554,14 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                             const avgYield = yieldMonthsCount > 0 ? sumYield / yieldMonthsCount : 0;
                                             const estAnnual = avgYield * 12;
                                             return (
-                                                <span
-                                                    title={lang === 'en'
+                                                <TooltipText
+                                                    tooltip={lang === 'en'
                                                         ? `Latest close: ${latestClosePrice[stock.stock_id]?.price || '-'}\nSum yield: ${sumYield.toFixed(1)}%\nEst. annual yield: ${estAnnual.toFixed(1)}%`
                                                         : `最新收盤價: ${latestClosePrice[stock.stock_id]?.price || '-'}\n加總殖利率: ${sumYield.toFixed(1)}%\n預估年化殖利率: ${estAnnual.toFixed(1)}%`}
-                                                    style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
+                                                    style={{ borderBottom: '1px dotted #777' }}
                                                 >
                                                     {Math.round(stockTotal).toLocaleString()}
-                                                </span>
+                                                </TooltipText>
                                             );
                                         })() : ''}</td>
                                         {MONTHS.map((m, idx) => {
@@ -569,14 +570,14 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                             const total = cell.dividend * cell.quantity;
                                             return (
                                                 <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: MONTH_COL_WIDTH }}>
-                                                    <span
-                                                        title={lang === 'en'
+                                                    <TooltipText
+                                                        tooltip={lang === 'en'
                                                             ? `Shares held: ${cell.quantity} (${(cell.quantity / 1000).toFixed(3).replace(/\.?0+$/, '')} lots)\nDividend per share: ${cell.dividend} \nClose before ex-date: ${cell.last_close_price}\nYield this time: ${cell.dividend_yield}\nEx-dividend date: ${cell.dividend_date || '-'}\nPayment date: ${cell.payment_date || '-'}`
                                                             : `持有數量: ${cell.quantity} 股 (${(cell.quantity / 1000).toFixed(3).replace(/\.?0+$/, '')} 張)\n每股配息: ${cell.dividend} 元\n除息前一天收盤價: ${cell.last_close_price}\n當次殖利率: ${cell.dividend_yield}\n配息日期: ${cell.dividend_date || '-'}\n發放日期: ${cell.payment_date || '-'}`}
-                                                        style={{ borderBottom: '1px dotted #777', cursor: 'help' }}
+                                                        style={{ borderBottom: '1px dotted #777' }}
                                                     >
                                                         {total > 0 ? Math.round(total).toLocaleString() : ''}
-                                                    </span>
+                                                    </TooltipText>
                                                 </td>
                                             );
                                         })}
@@ -590,8 +591,8 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
             </div>
             <p style={{ fontSize: 12, marginTop: 8, color: '#666' }}>
                 {lang === 'en'
-                    ? 'Tip: hover numbers to see holdings, per-share dividends, dates, prices and yield details.'
-                    : '提示：滑鼠移到數字可看持股、每股配息及日期、價格與殖利率細節。'}
+                    ? 'Tip: tap or hover numbers to see holdings, per-share dividends, dates, prices and yield details.'
+                    : '提示：點擊或滑鼠移到數字可看持股、每股配息及日期、價格與殖利率細節。'}
             </p>
         </div>
     );

--- a/apps/etf-life/src/components/StockTable.jsx
+++ b/apps/etf-life/src/components/StockTable.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef } from 'react';
 // Removed react-window virtualization to avoid invalid table markup
 import FilterDropdown from './FilterDropdown';
 import AdvancedFilterDropdown from './AdvancedFilterDropdown';
+import TooltipText from './TooltipText';
 import { HOST_URL } from '../config';
 import { useLanguage } from '../i18n';
 import usePreserveScroll from '../hooks/usePreserveScroll';
@@ -105,12 +106,12 @@ export default function StockTable({
       ? (yieldSum[stock.stock_id] > 0 ? `${yieldSum[stock.stock_id].toFixed(1)}%` : '')
       : (totalPerStock[stock.stock_id] > 0 ? totalPerStock[stock.stock_id].toFixed(1) : '');
     const annualVal = estAnnualYield[stock.stock_id] > 0 ? (
-      <span title={`${lang === 'zh' ? '目前已累積殖利率' : 'Accumulated yield so far'}: ${(yieldSum[stock.stock_id] || 0).toFixed(1)}%`}>
+      <TooltipText tooltip={`${lang === 'zh' ? '目前已累積殖利率' : 'Accumulated yield so far'}: ${(yieldSum[stock.stock_id] || 0).toFixed(1)}%`}>
         {estAnnualYield[stock.stock_id].toFixed(1)}%
         {estAnnualYield[stock.stock_id] === maxAnnualYield && maxAnnualYield > 0 && (
           <span className="crown-icon" role="img" aria-label="crown">👑</span>
         )}
-      </span>
+      </TooltipText>
     ) : '';
 
     return (
@@ -159,14 +160,14 @@ export default function StockTable({
           const paymentDate = cell.payment_date || '-';
           return (
             <td key={idx} className={idx === currentMonth ? 'current-month' : ''} style={{ width: NUM_COL_WIDTH }}>
-              <span
-                title={`${t('prev_close')}: ${lastClose}\n${t('current_yield')}: ${tooltipYield}\n${t('avg_month_yield')}: ${perYield.toFixed(2)}%\n${t('payout_frequency')}: ${freqNameMap[freq] || t('irregular')}\n${t('dividend_date')}: ${dividendDate}\n${t('payment_date')}: ${paymentDate}${extraInfo}`}
+              <TooltipText
+                tooltip={`${t('prev_close')}: ${lastClose}\n${t('current_yield')}: ${tooltipYield}\n${t('avg_month_yield')}: ${perYield.toFixed(2)}%\n${t('payout_frequency')}: ${freqNameMap[freq] || t('irregular')}\n${t('dividend_date')}: ${dividendDate}\n${t('payment_date')}: ${paymentDate}${extraInfo}`}
               >
                 {displayVal}
                 {perYield === maxYieldPerMonth[idx] && maxYieldPerMonth[idx] > 0 && (
                   <span className="diamond-icon" role="img" aria-label="diamond">💎</span>
                 )}
-              </span>
+              </TooltipText>
             </td>
           );
         })}

--- a/apps/etf-life/src/components/TooltipText.jsx
+++ b/apps/etf-life/src/components/TooltipText.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+
+const DEFAULT_BREAKPOINT = 768;
+
+const getMatches = (query) => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(query).matches;
+};
+
+export default function TooltipText({
+  tooltip,
+  children,
+  className = '',
+  style = {},
+  breakpoint = DEFAULT_BREAKPOINT
+}) {
+  const [isMobile, setIsMobile] = useState(() => getMatches(`(max-width: ${breakpoint}px)`));
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return () => {};
+    }
+
+    const mediaQuery = window.matchMedia(`(max-width: ${breakpoint}px)`);
+
+    const handleChange = (event) => {
+      setIsMobile(event.matches);
+    };
+
+    handleChange(mediaQuery);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [breakpoint]);
+
+  useEffect(() => {
+    if (!isMobile && open) {
+      setOpen(false);
+    }
+  }, [isMobile, open]);
+
+  const hasTooltip = typeof tooltip === 'string' ? tooltip.trim().length > 0 : Boolean(tooltip);
+
+  if (!hasTooltip) {
+    return (
+      <span className={className} style={style}>
+        {children}
+      </span>
+    );
+  }
+
+  const combinedClassName = ['tooltip-text', className].filter(Boolean).join(' ');
+  const combinedStyle = {
+    display: 'inline-block',
+    ...style,
+  };
+  if (!style.cursor) {
+    combinedStyle.cursor = isMobile ? 'pointer' : 'help';
+  }
+
+  const toggle = () => {
+    if (isMobile) {
+      setOpen((prev) => !prev);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (!isMobile) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  const tooltipLines = String(tooltip).split('\n');
+
+  return (
+    <span
+      className={combinedClassName}
+      style={combinedStyle}
+      title={isMobile ? undefined : tooltip}
+      role={isMobile ? 'button' : undefined}
+      tabIndex={isMobile ? 0 : undefined}
+      aria-expanded={isMobile ? open : undefined}
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
+      onBlur={() => setOpen(false)}
+    >
+      {children}
+      {isMobile && open && (
+        <span className="tooltip-inline">
+          {tooltipLines.map((line, idx) => (
+            <span key={`${line}-${idx}`}>
+              {line}
+              {idx < tooltipLines.length - 1 && <br />}
+            </span>
+          ))}
+        </span>
+      )}
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a reusable TooltipText component that renders inline details when tapped on mobile
- replace title-based dividend tips in the user dividends and stock tables with the new component and refresh the guidance copy
- add shared tooltip styling so the inline helper text is readable on small screens

## Testing
- pnpm --filter etf-life test

------
https://chatgpt.com/codex/tasks/task_e_68df9cf298bc8329ac0d441ce71952b1