### PR TITLE
feat: float mobile tooltips

### DIFF
--- a/apps/etf-life/src/App.css
+++ b/apps/etf-life/src/App.css
@@ -778,7 +778,6 @@ button:active {
 
 .tooltip-text .tooltip-inline {
   display: block;
-  position: relative;
   margin-top: 6px;
   padding: 8px;
   border-radius: 6px;
@@ -791,4 +790,14 @@ button:active {
   z-index: 1;
   max-width: min(280px, calc(100vw - 48px));
   word-break: break-word;
+}
+
+.tooltip-text .tooltip-inline-floating {
+  position: fixed;
+  margin-top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 16px;
+  z-index: 1000;
+  max-width: min(280px, calc(100vw - 32px));
 }


### PR DESCRIPTION
## Summary
- reposition TooltipText mobile tooltips as floating overlays that follow their trigger without affecting layout
- update tooltip styles to support fixed positioning with higher z-index for mobile displays

## Testing
- pnpm --filter etf-life test -- --runTestsByPath apps/etf-life/tests/HomeTab.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68dfa845afe08329bf681f8a6677b145