### PR TITLE
Handle multi-fragment dividend values when parsing

### DIFF
--- a/apps/etf-life/src/App.jsx
+++ b/apps/etf-life/src/App.jsx
@@ -18,6 +18,7 @@ import { API_HOST } from './config';
 import { fetchWithCache } from './api';
 import { getTomorrowDividendAlerts } from './utils/dividendUtils';
 import { fetchDividendsByYears, clearDividendsCache } from './dividendApi';
+import { parseNumeric } from './utils/numberUtils';
 
 const DEFAULT_MONTHLY_GOAL = 10000;
 
@@ -29,19 +30,6 @@ const hasPayload = (value) =>
   value !== undefined &&
   value !== null &&
   (typeof value === 'number' || (typeof value === 'string' && value.trim() !== ''));
-
-const parseNumeric = (value) => {
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : NaN;
-  }
-  if (typeof value === 'string') {
-    const cleaned = value
-      .replace(/[\s,]+/g, '')
-      .match(/[+-]?(?:\d+(?:\.\d*)?|\.\d+)/);
-    return cleaned ? Number(cleaned[0]) : NaN;
-  }
-  return NaN;
-};
 
 const DEFAULT_WATCH_GROUPS = [
   {
@@ -396,8 +384,8 @@ function App() {
         cell.dividend_yield = 0;
       }
 
-      const dividendValue = Number(item.dividend);
-      const yieldValue = Number(item.dividend_yield);
+      const dividendValue = parseNumeric(item.dividend);
+      const yieldValue = parseNumeric(item.dividend_yield);
       const hasRawDividend = item.dividend !== undefined && item.dividend !== null && `${item.dividend}`.trim() !== '';
       const hasRawYield = item.dividend_yield !== undefined && item.dividend_yield !== null && `${item.dividend_yield}`.trim() !== '';
 
@@ -471,7 +459,7 @@ function App() {
         let count = 0;
         for (let i = 0; i < 12; i++) {
           const cell = dividendTable[stock.stock_id]?.[i];
-          const y = parseFloat(cell?.dividend_yield) || 0;
+          const y = parseNumeric(cell?.dividend_yield) || 0;
           if (y > 0) {
             total += y;
             count += 1;
@@ -582,8 +570,8 @@ function App() {
       selectedStockIds.length === 0 || selectedStockIds.includes(item.stock_id)
     )
     .flatMap(item => {
-      const amount = parseFloat(item.dividend);
-      const dividend_yield = parseFloat(item.dividend_yield) || 0;
+      const amount = parseNumeric(item.dividend);
+      const dividend_yield = parseNumeric(item.dividend_yield) || 0;
       const arr = [];
       if (item.dividend_date) {
         arr.push({

--- a/apps/etf-life/src/InventoryTab.jsx
+++ b/apps/etf-life/src/InventoryTab.jsx
@@ -13,6 +13,7 @@ import { exportTransactionsToDrive, importTransactionsFromDrive } from './google
 import { exportTransactionsToOneDrive, importTransactionsFromOneDrive } from './oneDrive';
 import { exportTransactionsToICloud, importTransactionsFromICloud } from './icloud';
 import { transactionsToCsv, transactionsFromCsv } from './utils/csvUtils';
+import { parseNumeric } from './utils/numberUtils';
 import AddTransactionModal from './components/AddTransactionModal';
 import SellModal from './components/SellModal';
 import TransactionHistoryTable from './components/TransactionHistoryTable';
@@ -845,7 +846,7 @@ export default function InventoryTab() {
         setDividendData(list);
         const priceMap = {};
         list.forEach(item => {
-          const price = parseFloat(item.last_close_price);
+          const price = parseNumeric(item.last_close_price);
           if (!item.stock_id || Number.isNaN(price)) return;
           if (!priceMap[item.stock_id] || new Date(item.dividend_date) > new Date(priceMap[item.stock_id].date)) {
             priceMap[item.stock_id] = { price, date: item.dividend_date };

--- a/apps/etf-life/src/UserDividendsTab.jsx
+++ b/apps/etf-life/src/UserDividendsTab.jsx
@@ -6,6 +6,7 @@ import { useLanguage } from './i18n';
 import usePreserveScroll from './hooks/usePreserveScroll';
 import { fetchWithCache } from './api';
 import TooltipText from './components/TooltipText';
+import { parseNumeric } from './utils/numberUtils';
 
 const MONTH_COL_WIDTH = 80;
 function getTransactionHistory() {
@@ -131,9 +132,9 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
     const calendarEvents = dividendData.flatMap(item => {
         const holdingDate = item.dividend_date || item.payment_date;
         const qty = getHolding(item.stock_id, holdingDate);
-        const dividend = parseFloat(item.dividend);
+        const dividend = parseNumeric(item.dividend);
         const amount = dividend * qty;
-        const dividend_yield = parseFloat(item.dividend_yield) || 0;
+        const dividend_yield = parseNumeric(item.dividend_yield) || 0;
         const arr = [];
         if (item.dividend_date) {
             arr.push({
@@ -222,7 +223,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
         if (!thisDate) return;
         const month = new Date(thisDate).getMonth();
         const stock_id = item.stock_id;
-        const dividend = parseFloat(item.dividend);
+        const dividend = parseNumeric(item.dividend);
         const quantity = getHolding(stock_id, thisDate);
         const avgCost = getAverageCostBeforeDate(stock_id, thisDate);
         const costBasis = avgCost > 0 && quantity > 0 ? avgCost * quantity : 0;
@@ -253,7 +254,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
             if (cell && cell.dividend && cell.quantity) {
                 const amt = cell.dividend * cell.quantity;
                 totalPerStock[stock.stock_id] += amt;
-                totalYield[stock.stock_id] += parseFloat(cell.dividend_yield) || 0;
+                totalYield[stock.stock_id] += parseNumeric(cell.dividend_yield) || 0;
                 // monthsCount should reflect the month of the payout
                 monthsCount[stock.stock_id] = m + 1;
 
@@ -303,7 +304,7 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
             if (!monthFilters[idx]) continue;
             const cell = dividendTable[stockId][idx];
             if (cell && cell.dividend && cell.quantity) {
-                sumYield += parseFloat(cell.dividend_yield) || 0;
+                sumYield += parseNumeric(cell.dividend_yield) || 0;
                 lastMonth = idx + 1;
             }
         }

--- a/apps/etf-life/src/components/StockTable.jsx
+++ b/apps/etf-life/src/components/StockTable.jsx
@@ -6,6 +6,7 @@ import TooltipText from './TooltipText';
 import { HOST_URL } from '../config';
 import { useLanguage } from '../i18n';
 import usePreserveScroll from '../hooks/usePreserveScroll';
+import { parseNumeric } from '../utils/numberUtils';
 
 const NUM_COL_WIDTH = 80;
 
@@ -68,8 +69,8 @@ export default function StockTable({
         case 'stock_name':
           return a.stock_name.localeCompare(b.stock_name) * dir;
         case 'latest_price': {
-          const aPrice = parseFloat(latestPrice[a.stock_id]?.price) || 0;
-          const bPrice = parseFloat(latestPrice[b.stock_id]?.price) || 0;
+          const aPrice = parseNumeric(latestPrice[a.stock_id]?.price) || 0;
+          const bPrice = parseNumeric(latestPrice[b.stock_id]?.price) || 0;
           return (aPrice - bPrice) * dir;
         }
         case 'total': {
@@ -86,10 +87,10 @@ export default function StockTable({
           if (sortConfig.column?.startsWith('month')) {
             const idx = Number(sortConfig.column.slice(5));
             const aVal = showDividendYield
-              ? parseFloat(dividendTable[a.stock_id]?.[idx]?.dividend_yield) || 0
+              ? parseNumeric(dividendTable[a.stock_id]?.[idx]?.dividend_yield) || 0
               : dividendTable[a.stock_id]?.[idx]?.dividend || 0;
             const bVal = showDividendYield
-              ? parseFloat(dividendTable[b.stock_id]?.[idx]?.dividend_yield) || 0
+              ? parseNumeric(dividendTable[b.stock_id]?.[idx]?.dividend_yield) || 0
               : dividendTable[b.stock_id]?.[idx]?.dividend || 0;
             return (aVal - bVal) * dir;
           }

--- a/apps/etf-life/src/utils/dividendUtils.js
+++ b/apps/etf-life/src/utils/dividendUtils.js
@@ -1,4 +1,5 @@
 import { readTransactionHistory } from './transactionStorage';
+import { parseNumeric } from './numberUtils';
 
 export function getTomorrowDividendAlerts(dividendData, history = readTransactionHistory()) {
   if (!Array.isArray(dividendData) || dividendData.length === 0) return [];
@@ -18,7 +19,7 @@ export function getTomorrowDividendAlerts(dividendData, history = readTransactio
   dividendData.forEach(item => {
     const qty = holdings[item.stock_id];
     if (!qty) return;
-    const dividend = parseFloat(item.dividend) || 0;
+    const dividend = parseNumeric(item.dividend) || 0;
     if (item.dividend_date === tomorrowStr) {
       alerts.push({ stock_id: item.stock_id, stock_name: item.stock_name, type: 'ex', dividend, quantity: qty, total: dividend * qty });
     }

--- a/apps/etf-life/src/utils/numberUtils.js
+++ b/apps/etf-life/src/utils/numberUtils.js
@@ -1,0 +1,119 @@
+const THIN_SPACE_REGEX = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+const DECIMAL_LIKE_REGEX = /[\uFF0E\u2024\uFE52\uFF61\u3002\u00B7\u0387\u2022\u2027\u2219\u22C5\u30FB\uFF65\u02D9\u2E30\u2E31\u2981\u2218\uA78F\u1427\u16EB\u318D]/g;
+const NUMERIC_FRAGMENT_REGEX = /[+-]?(?:\d{1,3}(?:[.,]\d{3})*|\d+)(?:[.,]\d+)?|[+-]?\.[0-9]+/g;
+
+function normalizeFullWidthChars(value) {
+  if (typeof value !== 'string') return value;
+  return value
+    // Digits ０-９ -> 0-9
+    .replace(/[\uFF10-\uFF19]/g, char => String.fromCharCode(char.charCodeAt(0) - 0xFF10 + 0x30))
+    // Full-width plus/minus signs → ASCII
+    .replace(/\uFF0B/g, '+')
+    .replace(/[\uFF0D\u2212]/g, '-')
+    // Treat thin-space style thousands separators as commas so later logic recognises them
+    .replace(THIN_SPACE_REGEX, ',')
+    // Common middle-dot / bullet style decimal separators → ASCII decimal point
+    .replace(DECIMAL_LIKE_REGEX, '.')
+    .replace(/[\uFF0C\uFE50\uFE10\uFE51\u3001]/g, ',');
+}
+
+export function parseNumeric(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : Number.NaN;
+  }
+
+  if (typeof value !== 'string') {
+    return Number.NaN;
+  }
+
+  const trimmed = normalizeFullWidthChars(value).trim();
+  if (!trimmed) return Number.NaN;
+
+  const sanitized = trimmed.replace(/[^0-9+.,-]/g, ' ');
+
+  const matches = sanitized.matchAll(NUMERIC_FRAGMENT_REGEX);
+
+  let bestResult = Number.NaN;
+  let bestAbs = -Infinity;
+
+  for (const match of matches) {
+    const candidate = match[0];
+    if (!candidate) continue;
+
+    const parsed = parseSanitizedNumeric(candidate);
+    if (!Number.isFinite(parsed)) continue;
+
+    const absValue = Math.abs(parsed);
+    if (!Number.isFinite(bestResult) || absValue > bestAbs) {
+      bestResult = parsed;
+      bestAbs = absValue;
+    }
+  }
+
+  return bestResult;
+}
+
+export default parseNumeric;
+
+function parseSanitizedNumeric(numericStr) {
+  if (!numericStr) return Number.NaN;
+
+  const sign = numericStr[0] === '+' || numericStr[0] === '-' ? numericStr[0] : '';
+  let body = sign ? numericStr.slice(1) : numericStr;
+  if (!body) return Number.NaN;
+
+  const separators = [];
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (ch === '.' || ch === ',') {
+      separators.push({ char: ch, index: i });
+    }
+  }
+
+  if (!separators.length) {
+    const digitsOnly = body.replace(/[^0-9]/g, '');
+    if (!digitsOnly) return Number.NaN;
+    const result = Number(`${sign}${digitsOnly}`);
+    return Number.isFinite(result) ? result : Number.NaN;
+  }
+
+  const lastSeparator = separators[separators.length - 1];
+  const fractionalLength = body.length - lastSeparator.index - 1;
+
+  let normalized;
+  if (separators.length === 1) {
+    const rawInteger = body.slice(0, lastSeparator.index).replace(/[,\.]/g, '');
+    const rawFractional = body.slice(lastSeparator.index + 1).replace(/[,\.]/g, '');
+    const treatAsThousands = fractionalLength === 3 && rawInteger && rawInteger[0] !== '0';
+    if (treatAsThousands) {
+      normalized = rawInteger + rawFractional;
+    } else {
+      const integerPart = rawInteger || '0';
+      normalized = rawFractional
+        ? `${integerPart}.${rawFractional}`
+        : integerPart;
+    }
+  } else {
+    const digitsOnly = body.replace(/[,\.]/g, '');
+    if (!digitsOnly) return Number.NaN;
+    const rawInteger = body.slice(0, lastSeparator.index).replace(/[,\.]/g, '');
+    const uniformSeparator = separators.every(({ char }) => char === separators[0].char);
+    const looksLikeThousands = uniformSeparator
+      && fractionalLength === 3
+      && rawInteger
+      && (rawInteger[0] !== '0' || rawInteger.length > 3);
+
+    if (looksLikeThousands) {
+      normalized = digitsOnly;
+    } else if (fractionalLength > 0) {
+      const integerDigits = digitsOnly.slice(0, digitsOnly.length - fractionalLength) || '0';
+      const fractionalDigits = digitsOnly.slice(digitsOnly.length - fractionalLength);
+      normalized = `${integerDigits}.${fractionalDigits}`;
+    } else {
+      normalized = digitsOnly;
+    }
+  }
+
+  const result = Number(`${sign}${normalized}`);
+  return Number.isFinite(result) ? result : Number.NaN;
+}

--- a/apps/etf-life/tests/numberUtils.test.js
+++ b/apps/etf-life/tests/numberUtils.test.js
@@ -1,0 +1,62 @@
+import { parseNumeric } from '../src/utils/numberUtils';
+
+describe('parseNumeric', () => {
+  it('returns the same number for numeric inputs', () => {
+    expect(parseNumeric(1.23)).toBe(1.23);
+  });
+
+  it('parses basic numeric strings', () => {
+    expect(parseNumeric('0.069')).toBeCloseTo(0.069);
+    expect(parseNumeric('  15 ')).toBe(15);
+  });
+
+  it('parses numbers with trailing text', () => {
+    expect(parseNumeric('0.069元')).toBeCloseTo(0.069);
+    expect(parseNumeric('4.5%')).toBeCloseTo(4.5);
+  });
+
+  it('parses thousands separators and decimal commas', () => {
+    expect(parseNumeric('1,234.56')).toBeCloseTo(1234.56);
+    expect(parseNumeric('0,069')).toBeCloseTo(0.069);
+    expect(parseNumeric('1,234,567')).toBe(1234567);
+    expect(parseNumeric('1.234.567')).toBe(1234567);
+    expect(parseNumeric('0,500,000')).toBe(500000);
+    expect(parseNumeric('1,23')).toBeCloseTo(1.23);
+  });
+
+  it('parses full-width characters', () => {
+    expect(parseNumeric('０．７５')).toBeCloseTo(0.75);
+    expect(parseNumeric('－０．５')).toBeCloseTo(-0.5);
+  });
+
+  it('parses ideographic punctuation used as decimal or thousands separators', () => {
+    expect(parseNumeric('0。069')).toBeCloseTo(0.069);
+    expect(parseNumeric('1、234')).toBe(1234);
+    expect(parseNumeric('0・069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0˙069')).toBeCloseTo(0.069);
+    expect(parseNumeric('1·234')).toBe(1234);
+  });
+
+  it('parses middle-dot variants and thin spaces returned by the API', () => {
+    expect(parseNumeric('0⸱069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0⸰069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0ꞏ069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0ᐧ069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0᛫069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0∘069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0ㆍ069')).toBeCloseTo(0.069);
+    expect(parseNumeric('0 069')).toBeCloseTo(0.069);
+    expect(parseNumeric('1 234')).toBe(1234);
+  });
+
+  it('prefers the most meaningful numeric fragment when multiple numbers exist', () => {
+    expect(parseNumeric('0.000（含稅0.069）')).toBeCloseTo(0.069);
+    expect(parseNumeric('0 (預估 0.068)')).toBeCloseTo(0.068);
+    expect(parseNumeric('含息0.000／預計 0.070')).toBeCloseTo(0.07);
+    expect(parseNumeric('-0.5 / 0.3')).toBeCloseTo(-0.5);
+  });
+
+  it('returns NaN for invalid input', () => {
+    expect(Number.isNaN(parseNumeric('not a number'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- select the most significant numeric fragment when parsing dividend strings so placeholders like 0.000（含稅0.069） resolve to the real value
- reuse the existing normalization logic via a helper to parse each fragment consistently
- add regression tests covering multi-number payloads to prevent future regressions

## Testing
- pnpm --filter etf-life test -- numberUtils

------
https://chatgpt.com/codex/tasks/task_e_68dfab17af608329800ae86f408335cf