### PR TITLE
Fix default ETF Life API host configuration

### DIFF
--- a/apps/etf-life/src/config.js
+++ b/apps/etf-life/src/config.js
@@ -1,2 +1,17 @@
-export const API_HOST = import.meta.env.VITE_API_HOST
-export const HOST_URL = import.meta.env.VITE_HOST_URL
+const env = typeof import.meta !== 'undefined' && import.meta.env ? import.meta.env : {};
+
+const normalize = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed.endsWith('/') ? trimmed.replace(/\/+$/, '') : trimmed;
+};
+
+const fallbackOrigin = () => {
+  if (typeof window === 'undefined' || !window.location || !window.location.origin) {
+    return '';
+  }
+  return window.location.origin;
+};
+
+export const API_HOST = normalize(env.VITE_API_HOST) || fallbackOrigin();
+export const HOST_URL = normalize(env.VITE_HOST_URL) || fallbackOrigin();


### PR DESCRIPTION
## Summary
- add runtime fallbacks for the ETF Life API and host URLs when environment variables are missing
- normalize configured hosts to avoid trailing slash issues

## Testing
- pnpm --filter etf-life test -- StockDetail.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e13540a08c8329b70bf1f1c1a5509b