### PR TITLE
Fix stock code filter modal layering above footer

### DIFF
--- a/apps/etf-life/src/components/FilterDropdown.jsx
+++ b/apps/etf-life/src/components/FilterDropdown.jsx
@@ -1,8 +1,9 @@
 import { useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import useClickOutside from './useClickOutside';
 import { useLanguage } from '../i18n';
 
-export default function FilterDropdown({ options, selected, setSelected, onClose }) {
+export default function FilterDropdown({ options, selected, setSelected, onClose, position }) {
   const ref = useRef();
   useClickOutside(ref, onClose);
   const { lang } = useLanguage();
@@ -38,8 +39,17 @@ export default function FilterDropdown({ options, selected, setSelected, onClose
     setTempSelected([]);
   };
 
-  return (
-    <div className="dropdown" ref={ref}>
+  const dropdownStyle = position
+    ? {
+        position: 'absolute',
+        top: position.top,
+        left: position.left,
+        zIndex: 2000
+      }
+    : undefined;
+
+  const dropdownContent = (
+    <div className="dropdown" ref={ref} style={dropdownStyle}>
       <input
         type="text"
         className="dropdown-search"
@@ -82,4 +92,10 @@ export default function FilterDropdown({ options, selected, setSelected, onClose
       </div>
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return dropdownContent;
+  }
+
+  return createPortal(dropdownContent, document.body);
 }


### PR DESCRIPTION
## Summary
- render the stock code filter dropdown via a portal anchored to the trigger so it appears above the footer
- track the dropdown position with scroll and resize listeners to keep it aligned with the filter button

## Testing
- pnpm --filter etf-life lint

------
https://chatgpt.com/codex/tasks/task_e_68e63c1a9d78832992f6c6a76fcab08c