### PR TITLE
Use logos for experience navigation

### DIFF
--- a/apps/dividend-life/src/UserDividendsTab.jsx
+++ b/apps/dividend-life/src/UserDividendsTab.jsx
@@ -949,12 +949,18 @@ export default function UserDividendsTab({ allDividendData, selectedYear }) {
                                     return `${currencyHeaderLabel(currency)}：最新收盤價 ${latest}\n加總殖利率 ${info.sumYield.toFixed(1)}%\n預估年化殖利率 ${estAnnual.toFixed(1)}%`;
                                 }).filter(Boolean);
 
+                                const hasName = Boolean(stock.stock_name);
+                                const displayText = hasName
+                                    ? `${stock.stock_id} (${stock.stock_name})`
+                                    : stock.stock_id;
+                                const tooltipText = stock.stock_name || stock.stock_id;
+
                                 return (
                                     <tr key={stock.stock_id + stock.stock_name}>
                                         <td className="stock-col">
                                             <a href={`${HOST_URL}/stock/${stock.stock_id}`} target="_blank" rel="noreferrer">
-                                                <TooltipText tooltip={stock.stock_name}>
-                                                    {stock.stock_id}
+                                                <TooltipText tooltip={tooltipText}>
+                                                    {displayText}
                                                 </TooltipText>
                                             </a>
                                         </td>

--- a/apps/shared/assets/balance-life-light.svg
+++ b/apps/shared/assets/balance-life-light.svg
@@ -1,0 +1,20 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="freshTeal" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1D8EB5" />
+      <stop offset="100%" stop-color="#6BC6FF" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="#F5FBFF" />
+  <g transform="translate(24,20)">
+    <path d="M0 28 L32 0 L64 28" fill="none" stroke="url(#freshTeal)" stroke-width="2.5" stroke-linecap="round" />
+    <circle cx="32" cy="32" r="12" fill="none" stroke="url(#freshTeal)" stroke-width="2.5" />
+    <line x1="12" y1="32" x2="52" y2="32" stroke="url(#freshTeal)" stroke-width="2.5" stroke-linecap="round" />
+  </g>
+  <text x="104" y="44" fill="#1F5D7D" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Balance Life
+  </text>
+  <text x="104" y="62" fill="#2C7EA7" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.85">
+    Plan, track, and align your wealth goals
+  </text>
+</svg>

--- a/apps/shared/assets/balance-life.svg
+++ b/apps/shared/assets/balance-life.svg
@@ -1,0 +1,20 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="tealGradient" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2BC0E4" />
+      <stop offset="100%" stop-color="#52A0FD" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="#0B0B0D" />
+  <g transform="translate(24,20)">
+    <path d="M0 28 L32 0 L64 28" fill="none" stroke="url(#tealGradient)" stroke-width="2.5" stroke-linecap="round" />
+    <circle cx="32" cy="32" r="12" fill="none" stroke="url(#tealGradient)" stroke-width="2.5" />
+    <line x1="12" y1="32" x2="52" y2="32" stroke="url(#tealGradient)" stroke-width="2.5" stroke-linecap="round" />
+  </g>
+  <text x="104" y="44" fill="url(#tealGradient)" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Balance Life
+  </text>
+  <text x="104" y="62" fill="#8CC4FF" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.9">
+    Plan, track, and align your wealth goals
+  </text>
+</svg>

--- a/apps/shared/assets/conceptb-life.svg
+++ b/apps/shared/assets/conceptb-life.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" fill="none">
+  <title>ConceptB Life Home</title>
+  <path
+    d="M48 128 C48 88 100 88 128 128 C156 168 208 168 208 128 C208 88 156 88 128 128 C100 168 48 168 48 128 Z"
+    fill="none"
+    stroke="#12B886"
+    stroke-width="20"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M188 118 L212 128 L194 142 Z" fill="#12B886" />
+</svg>

--- a/apps/shared/assets/dividend-life-light.svg
+++ b/apps/shared/assets/dividend-life-light.svg
@@ -1,0 +1,18 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sunlitGold" x1="0" x2="1">
+      <stop offset="0%" stop-color="#B17F19"/>
+      <stop offset="100%" stop-color="#F0C75E"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="80" fill="#FBF7EE"/>
+  <circle cx="40" cy="40" r="20" fill="none" stroke="url(#sunlitGold)" stroke-width="2"/>
+  <path d="M40 20 L40 60 M20 40 L60 40" stroke="url(#sunlitGold)" stroke-width="2" stroke-linecap="round" opacity="0.95"/>
+  <path d="M25 50 C35 55, 45 55, 55 50" stroke="url(#sunlitGold)" stroke-width="2" fill="none" opacity="0.95"/>
+  <text x="80" y="46" fill="#6B4E16" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Dividend Life
+  </text>
+  <text x="80" y="64" fill="#8C6A1F" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.85">
+    Let your money work for you
+  </text>
+</svg>

--- a/apps/shared/assets/dividend-life.svg
+++ b/apps/shared/assets/dividend-life.svg
@@ -1,0 +1,20 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gold" x1="0" x2="1">
+      <stop offset="0%" stop-color="#D4AF37"/>
+      <stop offset="100%" stop-color="#F5E6A3"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="80" fill="#0B0B0D"/>
+  <!-- 幣/分紅圓與分配線 -->
+  <circle cx="40" cy="40" r="20" fill="none" stroke="url(#gold)" stroke-width="2"/>
+  <path d="M40 20 L40 60 M20 40 L60 40" stroke="url(#gold)" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+  <path d="M25 50 C35 55, 45 55, 55 50" stroke="url(#gold)" stroke-width="2" fill="none" opacity="0.9"/>
+  <!-- 文字 -->
+  <text x="80" y="46" fill="url(#gold)" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Dividend Life
+  </text>
+  <text x="80" y="64" fill="#B7A972" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.9">
+    Let your money work for you
+  </text>
+</svg>

--- a/apps/shared/assets/health-life-light.svg
+++ b/apps/shared/assets/health-life-light.svg
@@ -1,0 +1,19 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="leafGlow" x1="0" x2="1">
+      <stop offset="0%" stop-color="#3BA272"/>
+      <stop offset="100%" stop-color="#7CDDC4"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="#F5FBF8"/>
+  <path d="M28 50 C15 40, 22 22, 40 25 C52 28, 55 42, 42 50 C38 52, 32 52, 28 50 Z"
+        fill="none" stroke="url(#leafGlow)" stroke-width="2"/>
+  <path d="M18 40 L28 40 L33 47 L38 33 L42 40 L52 40" stroke="url(#leafGlow)" stroke-width="2" fill="none"
+        stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="80" y="46" fill="#225C46" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Health Life
+  </text>
+  <text x="80" y="64" fill="#2D7B5A" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.85">
+    Invest in your body first
+  </text>
+</svg>

--- a/apps/shared/assets/health-life.svg
+++ b/apps/shared/assets/health-life.svg
@@ -1,0 +1,21 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gold" x1="0" x2="1">
+      <stop offset="0%" stop-color="#D4AF37"/>
+      <stop offset="100%" stop-color="#F5E6A3"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="#0B0B0D"/>
+  <!-- 葉子 + 心跳 -->
+  <path d="M28 50 C15 40, 22 22, 40 25 C52 28, 55 42, 42 50 C38 52, 32 52, 28 50 Z"
+        fill="none" stroke="url(#gold)" stroke-width="2"/>
+  <path d="M18 40 L28 40 L33 47 L38 33 L42 40 L52 40" stroke="url(#gold)" stroke-width="2" fill="none"
+        stroke-linejoin="round" stroke-linecap="round"/>
+  <!-- 文字 -->
+  <text x="80" y="46" fill="url(#gold)" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Health Life
+  </text>
+  <text x="80" y="64" fill="#B7A972" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.9">
+    Invest in your body first
+  </text>
+</svg>

--- a/apps/shared/assets/wealth-life-light.svg
+++ b/apps/shared/assets/wealth-life-light.svg
@@ -1,0 +1,18 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sunriseGold" x1="0" x2="1">
+      <stop offset="0%" stop-color="#B17F19"/>
+      <stop offset="100%" stop-color="#F0C75E"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="#FBF7EE"/>
+  <path d="M20 52 L20 42 M30 52 L30 38 M40 52 L40 34 M50 52 L50 28" stroke="url(#sunriseGold)" stroke-width="3" stroke-linecap="round"/>
+  <path d="M20 28 L35 22 L58 30" stroke="url(#sunriseGold)" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M58 30 L55 27 L64 26 L62 35 Z" fill="url(#sunriseGold)"/>
+  <text x="80" y="46" fill="#6B4E16" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Wealth Life
+  </text>
+  <text x="80" y="64" fill="#8C6A1F" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.85">
+    Grow, protect, and enjoy
+  </text>
+</svg>

--- a/apps/shared/assets/wealth-life.svg
+++ b/apps/shared/assets/wealth-life.svg
@@ -1,0 +1,20 @@
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gold" x1="0" x2="1">
+      <stop offset="0%" stop-color="#D4AF37"/>
+      <stop offset="100%" stop-color="#F5E6A3"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="#0B0B0D"/>
+  <!-- 上升箭頭 + 柱狀 -->
+  <path d="M20 52 L20 42 M30 52 L30 38 M40 52 L40 34 M50 52 L50 28" stroke="url(#gold)" stroke-width="3" stroke-linecap="round"/>
+  <path d="M20 28 L35 22 L58 30" stroke="url(#gold)" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M58 30 L55 27 L64 26 L62 35 Z" fill="url(#gold)"/>
+  <!-- 文字 -->
+  <text x="80" y="46" fill="url(#gold)" font-family="Poppins, Montserrat, system-ui" font-size="24" font-weight="600">
+    Wealth Life
+  </text>
+  <text x="80" y="64" fill="#B7A972" font-family="Poppins, Montserrat, system-ui" font-size="12" opacity="0.9">
+    Grow, protect, and enjoy
+  </text>
+</svg>

--- a/apps/shared/components/ExperienceNavigation/ExperienceNavigation.jsx
+++ b/apps/shared/components/ExperienceNavigation/ExperienceNavigation.jsx
@@ -1,13 +1,46 @@
 import { useThemeLanguage } from '@shared/hooks/useThemeLanguage.jsx';
 import { Link } from '@shared/router';
+import conceptbLifeLogo from '@shared/assets/conceptb-life.svg';
+import dividendLifeLogoDark from '@dividend-life/assets/dividend-life.svg';
+import dividendLifeLogoLight from '@dividend-life/assets/dividend-life-light.svg';
+import balanceLifeLogoDark from '@balance-life/assets/balance-life.svg';
+import balanceLifeLogoLight from '@balance-life/assets/balance-life-light.svg';
+import healthLifeLogoDark from '@health-life/assets/health-life.svg';
+import healthLifeLogoLight from '@health-life/assets/health-life-light.svg';
+import wealthLifeLogoDark from '@wealth-life/assets/wealth-life.svg';
+import wealthLifeLogoLight from '@wealth-life/assets/wealth-life-light.svg';
 import styles from './ExperienceNavigation.module.css';
 
 const baseExperiences = [
-  { key: 'home', labels: { zh: '首頁', en: 'Home' } },
-  { key: 'dividend-life', to: '/dividend-life', labels: { zh: 'Dividend Life', en: 'Dividend Life' } },
-  { key: 'balance-life', to: '/balance-life', labels: { zh: 'Balance Life', en: 'Balance Life' } },
-  { key: 'health-life', to: '/health-life', labels: { zh: 'Health Life', en: 'Health Life' } },
-  { key: 'wealth-life', to: '/wealth-life', labels: { zh: 'Wealth Life', en: 'Wealth Life' } },
+  {
+    key: 'home',
+    labels: { zh: '首頁', en: 'Home' },
+    logos: { dark: conceptbLifeLogo, light: conceptbLifeLogo },
+  },
+  {
+    key: 'dividend-life',
+    to: '/dividend-life',
+    labels: { zh: 'Dividend Life', en: 'Dividend Life' },
+    logos: { dark: dividendLifeLogoDark, light: dividendLifeLogoLight },
+  },
+  {
+    key: 'balance-life',
+    to: '/balance-life',
+    labels: { zh: 'Balance Life', en: 'Balance Life' },
+    logos: { dark: balanceLifeLogoDark, light: balanceLifeLogoLight },
+  },
+  {
+    key: 'health-life',
+    to: '/health-life',
+    labels: { zh: 'Health Life', en: 'Health Life' },
+    logos: { dark: healthLifeLogoDark, light: healthLifeLogoLight },
+  },
+  {
+    key: 'wealth-life',
+    to: '/wealth-life',
+    labels: { zh: 'Wealth Life', en: 'Wealth Life' },
+    logos: { dark: wealthLifeLogoDark, light: wealthLifeLogoLight },
+  },
 ];
 
 export default function ExperienceNavigation({
@@ -15,7 +48,7 @@ export default function ExperienceNavigation({
   homeHref = '/',
   homeNavigation = 'router',
 }) {
-  const { lang } = useThemeLanguage();
+  const { theme, lang } = useThemeLanguage();
   const experiences = baseExperiences.map((experience) =>
     experience.key === 'home'
       ? { ...experience, to: homeHref }
@@ -32,6 +65,10 @@ export default function ExperienceNavigation({
           experience.labels?.zh ??
           experience.labels?.en ??
           experience.key;
+        const logo =
+          experience.logos?.[theme] ??
+          experience.logos?.dark ??
+          experience.logos?.light;
 
         return (
           <Link
@@ -41,7 +78,10 @@ export default function ExperienceNavigation({
             aria-current={isActive ? 'page' : undefined}
             reloadDocument={experience.key === 'home' ? shouldReloadHome : false}
           >
-            {label}
+            <span className={styles.logoWrapper} aria-hidden="true">
+              <img src={logo} alt="" className={styles.logo} />
+            </span>
+            <span className={styles.label}>{label}</span>
           </Link>
         );
       })}

--- a/apps/shared/components/ExperienceNavigation/ExperienceNavigation.jsx
+++ b/apps/shared/components/ExperienceNavigation/ExperienceNavigation.jsx
@@ -1,14 +1,14 @@
 import { useThemeLanguage } from '@shared/hooks/useThemeLanguage.jsx';
 import { Link } from '@shared/router';
 import conceptbLifeLogo from '@shared/assets/conceptb-life.svg';
-import dividendLifeLogoDark from '@dividend-life/assets/dividend-life.svg';
-import dividendLifeLogoLight from '@dividend-life/assets/dividend-life-light.svg';
-import balanceLifeLogoDark from '@balance-life/assets/balance-life.svg';
-import balanceLifeLogoLight from '@balance-life/assets/balance-life-light.svg';
-import healthLifeLogoDark from '@health-life/assets/health-life.svg';
-import healthLifeLogoLight from '@health-life/assets/health-life-light.svg';
-import wealthLifeLogoDark from '@wealth-life/assets/wealth-life.svg';
-import wealthLifeLogoLight from '@wealth-life/assets/wealth-life-light.svg';
+import dividendLifeLogoDark from '@shared/assets/dividend-life.svg';
+import dividendLifeLogoLight from '@shared/assets/dividend-life-light.svg';
+import balanceLifeLogoDark from '@shared/assets/balance-life.svg';
+import balanceLifeLogoLight from '@shared/assets/balance-life-light.svg';
+import healthLifeLogoDark from '@shared/assets/health-life.svg';
+import healthLifeLogoLight from '@shared/assets/health-life-light.svg';
+import wealthLifeLogoDark from '@shared/assets/wealth-life.svg';
+import wealthLifeLogoLight from '@shared/assets/wealth-life-light.svg';
 import styles from './ExperienceNavigation.module.css';
 
 const baseExperiences = [

--- a/apps/shared/components/ExperienceNavigation/ExperienceNavigation.module.css
+++ b/apps/shared/components/ExperienceNavigation/ExperienceNavigation.module.css
@@ -2,40 +2,154 @@
   width: min(960px, 100%);
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 16px;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   margin-bottom: 24px;
 }
 
 .link {
-  padding: 10px 18px;
-  border-radius: 999px;
-  border: 1px solid rgba(128, 156, 255, 0.3);
-  background: rgba(12, 14, 20, 0.65);
-  color: rgba(232, 236, 255, 0.86);
+  position: relative;
+  padding: 18px 20px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(128, 156, 255, 0.25);
+  background: radial-gradient(circle at top, rgba(63, 109, 255, 0.28), rgba(12, 14, 20, 0.85));
+  color: rgba(232, 236, 255, 0.9);
   font-size: 0.95rem;
   text-decoration: none;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  min-width: 120px;
+  box-shadow: 0 12px 28px rgba(8, 15, 40, 0.45);
+}
+
+.logoWrapper {
+  width: 72px;
+  height: 72px;
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(20, 26, 48, 0.95), rgba(12, 14, 24, 0.8));
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(128, 156, 255, 0.35);
+  box-shadow: inset 0 4px 8px rgba(18, 24, 48, 0.6), 0 12px 22px rgba(10, 18, 42, 0.45);
+  overflow: hidden;
+}
+
+.logo {
+  width: 56px;
+  height: 56px;
+  object-fit: contain;
+}
+
+.label {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(212, 220, 255, 0.78);
+  text-align: center;
 }
 
 .link:hover,
 .link:focus-visible {
-  background: rgba(128, 156, 255, 0.2);
-  border-color: rgba(140, 173, 255, 0.45);
-  transform: translateY(-1px);
+  transform: translateY(-4px);
+  border-color: rgba(140, 173, 255, 0.5);
+  box-shadow: 0 18px 32px rgba(29, 60, 140, 0.55);
   outline: none;
+  background: radial-gradient(circle at top, rgba(82, 124, 255, 0.35), rgba(16, 20, 40, 0.92));
+}
+
+.link:hover .logoWrapper,
+.link:focus-visible .logoWrapper {
+  border-color: rgba(166, 190, 255, 0.6);
+  box-shadow: inset 0 6px 10px rgba(26, 34, 62, 0.75), 0 18px 26px rgba(29, 60, 140, 0.5);
 }
 
 .active {
-  background: linear-gradient(135deg, rgba(102, 132, 255, 0.9), rgba(66, 105, 255, 0.9));
-  border-color: rgba(140, 173, 255, 0.7);
+  border-color: rgba(166, 190, 255, 0.75);
+  background: linear-gradient(145deg, rgba(82, 124, 255, 0.85), rgba(44, 92, 255, 0.9));
   color: #f8faff;
+  box-shadow: 0 22px 40px rgba(40, 72, 170, 0.6);
   pointer-events: none;
+}
+
+.active .logoWrapper {
+  background: linear-gradient(145deg, rgba(18, 28, 72, 0.95), rgba(10, 14, 34, 0.9));
+  border-color: rgba(212, 226, 255, 0.85);
+  box-shadow: inset 0 6px 12px rgba(28, 38, 88, 0.8), 0 20px 32px rgba(34, 72, 170, 0.55);
+}
+
+.active .label {
+  color: #ffffff;
+}
+
+:global([data-theme='light']) .link {
+  border-color: rgba(103, 136, 255, 0.25);
+  background: radial-gradient(circle at top, rgba(120, 152, 255, 0.18), rgba(255, 255, 255, 0.95));
+  color: rgba(27, 39, 78, 0.85);
+  box-shadow: 0 10px 24px rgba(126, 152, 255, 0.25);
+}
+
+:global([data-theme='light']) .logoWrapper {
+  background: linear-gradient(145deg, rgba(238, 243, 255, 0.98), rgba(220, 230, 255, 0.85));
+  border-color: rgba(120, 152, 255, 0.35);
+  box-shadow: inset 0 4px 8px rgba(182, 198, 255, 0.45), 0 10px 20px rgba(120, 152, 255, 0.25);
+}
+
+:global([data-theme='light']) .label {
+  color: rgba(27, 39, 78, 0.7);
+}
+
+:global([data-theme='light']) .link:hover,
+:global([data-theme='light']) .link:focus-visible {
+  background: radial-gradient(circle at top, rgba(140, 168, 255, 0.24), rgba(246, 249, 255, 0.98));
+  border-color: rgba(120, 152, 255, 0.55);
+  box-shadow: 0 18px 30px rgba(120, 152, 255, 0.35);
+}
+
+:global([data-theme='light']) .link:hover .logoWrapper,
+:global([data-theme='light']) .link:focus-visible .logoWrapper {
+  border-color: rgba(140, 168, 255, 0.6);
+  box-shadow: inset 0 6px 12px rgba(200, 214, 255, 0.6), 0 18px 26px rgba(120, 152, 255, 0.28);
+}
+
+:global([data-theme='light']) .active {
+  background: linear-gradient(145deg, rgba(126, 152, 255, 0.9), rgba(92, 128, 255, 0.95));
+  border-color: rgba(160, 186, 255, 0.9);
+  color: #0f1324;
+  box-shadow: 0 20px 36px rgba(120, 152, 255, 0.45);
+}
+
+:global([data-theme='light']) .active .logoWrapper {
+  background: linear-gradient(145deg, rgba(230, 236, 255, 0.98), rgba(210, 222, 255, 0.9));
+  border-color: rgba(198, 212, 255, 0.95);
+}
+
+:global([data-theme='light']) .active .label {
+  color: rgba(10, 18, 42, 0.9);
 }
 
 @media (max-width: 640px) {
   .nav {
     justify-content: flex-start;
+    gap: 12px;
+  }
+
+  .link {
+    padding: 16px;
+    min-width: 104px;
+  }
+
+  .logoWrapper {
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+  }
+
+  .logo {
+    width: 48px;
+    height: 48px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the top experience navigation buttons with branded logos while keeping accessible labels
- refresh the navigation styling with theme-aware hover and active states to highlight the logo presentation
- add a shared ConceptB logo asset for the home navigation entry

## Testing
- pnpm -r lint *(fails: existing no-unused-vars errors in apps/dividend-life/src/dividendApi.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3e5120cc83299f9891daf7f9eb47)