### PR TITLE
Refresh stock prices on tab focus after idle

### DIFF
--- a/apps/dividend-life/src/DividendLifePage.jsx
+++ b/apps/dividend-life/src/DividendLifePage.jsx
@@ -469,29 +469,12 @@ function DividendLifePage({ homeHref = '/', homeNavigation = 'router' } = {}) {
     setUpcomingAlerts(getTomorrowDividendAlerts(data));
   }, [data]);
 
-  useEffect(() => {
-    const STALE_THRESHOLD = 30 * 60 * 1000; // 30 minutes
-    const handleVisibility = () => {
-      if (document.visibilityState === 'visible') {
-        const age = Date.now() - lastFetchedAt.current;
-        if (age > STALE_THRESHOLD) {
-          setRefreshTrigger(n => n + 1);
-        }
-      }
-    };
-    document.addEventListener('visibilitychange', handleVisibility);
-    return () => document.removeEventListener('visibilitychange', handleVisibility);
-  }, []);
-
-  useEffectOnce(() => {
-    let cancelled = false;
-
-    fetchStockList()
+  const loadStockList = useCallback(() => {
+    const freqMapRaw = { '年配': 1, '半年配': 2, '季配': 4, '雙月配': 6, '月配': 12, '週配': 52 };
+    return fetchStockList()
       .then(({ list }) => {
-        if (cancelled) return;
         const map = {};
         const priceMap = {};
-        const freqMapRaw = { '年配': 1, '半年配': 2, '季配': 4, '雙月配': 6, '月配': 12, '週配': 52 };
         list.forEach(s => {
           map[s.stock_id] = freqMapRaw[s.dividend_frequency] || null;
           if (s.latest_close_price != null) {
@@ -500,12 +483,30 @@ function DividendLifePage({ homeHref = '/', homeNavigation = 'router' } = {}) {
         });
         setFreqMap(map);
         setStockListPriceMap(priceMap);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setFreqMap({});
-        }
       });
+  }, []);
+
+  useEffect(() => {
+    const STALE_THRESHOLD = 30 * 60 * 1000; // 30 minutes
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        const age = Date.now() - lastFetchedAt.current;
+        if (age > STALE_THRESHOLD) {
+          setRefreshTrigger(n => n + 1);
+          loadStockList().catch(() => {});
+        }
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [loadStockList]);
+
+  useEffectOnce(() => {
+    let cancelled = false;
+
+    loadStockList().catch(() => {
+      if (!cancelled) setFreqMap({});
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary

- `fetchStockList`（含 `latest_close_price`）原本只在元件 mount 時透過 `useEffectOnce` 呼叫一次，導致使用者長時間停留在頁面而不重新整理時，股價資料會停留在最初載入時的狀態
- 現有的 `visibilitychange` handler 在 tab 重新取得焦點後已會重抓配息資料（idle > 30 分鐘），但沒有一併更新股價
- 將 stock list 處理邏輯抽出為 `loadStockList` useCallback，並在初始 mount 與 visibility-change handler 中都呼叫，使股價與配息資料保持同步更新

## Test plan

- [ ] 開啟頁面，記錄目前顯示的股價
- [ ] 將 tab 切到背景超過 30 分鐘（或手動將 `lastFetchedAt` 設為舊時間）
- [ ] 切回 tab，確認股價與配息資料都有重新從 server 取得
- [ ] 確認初次載入股價行為與修改前相同

https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a)_