### PR TITLE
Fix mobile nav tab wrapping and per-lot dividend formatting

### DIFF
--- a/apps/dividend-life/src/App.css
+++ b/apps/dividend-life/src/App.css
@@ -2881,6 +2881,10 @@ button.metric-card:focus-visible {
 }
 
 /* ── Tab bar horizontal scroll on mobile ── */
+.nav.nav-tabs .nav-link {
+  white-space: nowrap;
+}
+
 .nav.nav-tabs {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;

--- a/apps/dividend-life/src/components/StockTable.jsx
+++ b/apps/dividend-life/src/components/StockTable.jsx
@@ -706,7 +706,7 @@ const StockRow = memo(function StockRow({
           key={`${stock.stock_id}-total-${currency}`}
           className="total-cell-row"
         >
-          <span>{`${currencyLabelFor(currency)}${total.toFixed(3)}`}</span>
+          <span>{`${currencyLabelFor(currency)}${currency === 'USD' ? total.toFixed(2) : Math.round(total)}`}</span>
           {annualContent && <span>/ {annualContent}</span>}
         </div>
       );


### PR DESCRIPTION
## Summary

- **Mobile nav tab wrapping**：`.nav-link` 缺少 `white-space: nowrap`，導致中文 tab 標籤在手機上一個字一行。加上此屬性後 tab 保持單行，超出螢幕時橫向捲動
- **每張配息格式**：台股（TWD）顯示整數，美股（USD）顯示小數點兩位，例如 `NT$1866`、`US$1.23`

## Test plan

- [ ] 手機瀏覽器查看 tab 導覽列，確認「首頁」「我的配息」「ETF 配息查詢」「庫存管理」「關於本站」各自顯示為單行文字
- [ ] ETF 配息查詢 → 已購買 ETF（台股）：確認「每張配息」欄顯示整數，如 `NT$1866`
- [ ] ETF 配息查詢 → 美股或台股/美股混合：確認美股部分顯示兩位小數，如 `US$1.23`

https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a)_