### PR TITLE
Fix table responsive layout: per-lot column, number format, nav tabs, sticky column

### DIFF
--- a/apps/dividend-life/src/App.css
+++ b/apps/dividend-life/src/App.css
@@ -1215,7 +1215,10 @@ button:active {
 .table-responsive table td:first-child {
   position: sticky;
   left: 0;
-  background: var(--color-card-bg);
+  background-color: var(--color-card-bg, #fff) !important;
+  /* Neutralise Bootstrap 5.3's inset-9999px box-shadow overlay so the
+     explicit background-color always covers horizontally-scrolled content */
+  box-shadow: none !important;
   z-index: 100;
 }
 
@@ -1249,14 +1252,15 @@ button:active {
   text-decoration: underline;
 }
 
-/* Override striped-row background so sticky column matches */
+/* Override striped-row background so sticky column matches.
+   !important needed to beat the td:first-child !important base rule above. */
 .table-striped > tbody > tr:nth-of-type(odd) > .stock-col,
 tr:nth-child(odd) .stock-col {
-  background: var(--color-row-odd, var(--bs-table-striped-bg, #f9f9f9));
+  background-color: var(--color-row-odd, var(--bs-table-striped-bg, #f9f9f9)) !important;
 }
 .table-striped > tbody > tr:nth-of-type(even) > .stock-col,
 tr:nth-child(even) .stock-col {
-  background: var(--color-row-even, var(--color-card-bg, #fff));
+  background-color: var(--color-row-even, var(--color-card-bg, #fff)) !important;
 }
 
 .row-label-cell {
@@ -1274,11 +1278,11 @@ tr:nth-child(even) .stock-col {
 
 .table-striped > tbody > tr:nth-of-type(odd) > .row-label-cell,
 tr:nth-child(odd) .row-label-cell {
-  background: var(--color-row-odd, var(--bs-table-striped-bg, #f3f4f6));
+  background-color: var(--color-row-odd, var(--bs-table-striped-bg, #f3f4f6)) !important;
 }
 .table-striped > tbody > tr:nth-of-type(even) > .row-label-cell,
 tr:nth-child(even) .row-label-cell {
-  background: var(--color-row-even, var(--color-card-bg, #fff));
+  background-color: var(--color-row-even, var(--color-card-bg, #fff)) !important;
 }
 
 .chart-empty-msg {


### PR DESCRIPTION
## Summary

- **Per-lot dividend column**: ETF search table now shows dividend per 1 lot (1000 shares) instead of multiplying by user holdings; "我的配息" table shows a new cumulative dividend / estimated annual yield column based on actual holdings
- **Number format**: Per-lot TWD amounts display as integers (`Math.round`), USD as 2 decimal places — removes the previous `.toFixed(3)` surplus digits (e.g. `NT$1866.000` → `NT$1,866`)
- **Mobile nav tabs**: Added `white-space: nowrap` to `.nav.nav-tabs .nav-link` so tab labels never wrap character-by-character on narrow screens
- **Sticky column bleed-through**: Fixed text from scrolled-behind columns bleeding into the frozen first column by setting `background-color !important` and `box-shadow: none !important` on `td/th:first-child`; striped-row overrides for `.stock-col` and `.row-label-cell` also get `!important` so alternating row colours are preserved

## Test plan

- [ ] Open ETF 配息查詢 on desktop and mobile — last column header should read "每張配息 / Per Lot" and values should be integers (TWD) or 2-decimal (USD)
- [ ] Open 我的配息 — verify new rightmost column shows cumulative dividend + estimated annual yield based on your actual holdings
- [ ] Resize browser to mobile width — nav tabs ("首頁", "庫存管理", "我的配息", "ETF 配息查詢") should each stay on one line without character wrapping
- [ ] On 我的配息, scroll the table right — the stock-ID column and "配息成本" / "月合計" label cells should stay pinned at left with a solid background, no digits from month columns bleeding through

https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a)_