### PR TITLE
Revert vertical-text tabs; keep full-width tab bar fix

### DIFF
--- a/apps/dividend-life/src/App.css
+++ b/apps/dividend-life/src/App.css
@@ -2912,17 +2912,7 @@ button.metric-card:focus-visible {
   display: none; /* Chrome/Safari */
 }
 
-@media (max-width: 640px) {
-  /* Horizontal tab bar, but each tab's text rendered vertically (直式) */
-  .nav.nav-tabs .nav-link {
-    writing-mode: vertical-lr;
-    text-orientation: mixed;
-    white-space: nowrap;
-    padding: 10px 6px;
-    min-height: 56px;
-    text-align: center;
-  }
-
+@media (max-width: 767px) {
   .nav.nav-tabs.justify-content-center {
     justify-content: flex-start !important;
   }


### PR DESCRIPTION
## Summary

- **Revert vertical-text tabs**: `writing-mode: vertical-lr` on Bootstrap nav-tabs flex items caused tabs to overlap and render completely broken on mobile. Reverted to the standard horizontal scrollable tab bar.
- **Keep full-width fix**: The `-2em` negative margin fix (matching `.card`'s `padding: 2em`) is retained so the tab bar background extends edge-to-edge on the card.

## Test plan

- [ ] On mobile, open the app — tabs should be a horizontal scrollable row with normal horizontal text, no overlap or layout breakage
- [ ] Tab bar background should extend to the left and right edges of the card (no 8 px gap as before)

https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a)_