### PR TITLE
Fix mobile tab bar alignment and responsive layout issues

### DIFF
--- a/apps/dividend-life/src/App.css
+++ b/apps/dividend-life/src/App.css
@@ -2912,12 +2912,6 @@ button.metric-card:focus-visible {
   display: none; /* Chrome/Safari */
 }
 
-@media (max-width: 767px) {
-  .nav.nav-tabs.justify-content-center {
-    justify-content: flex-start !important;
-  }
-}
-
 /* ── Sticky filter bar (stock table) ── */
 .filter-bar {
   position: sticky;


### PR DESCRIPTION
## Summary

- Fix sticky column background bleed-through in scrollable table (Bootstrap 5 `box-shadow` inset conflict)
- Fix ExperienceNavigation active border not fully enclosing the logo icon on mobile
- Fix mobile nav tab bar width — extends to full card width using `-2em` / `2em` margin/padding
- Remove `justify-content: flex-start !important` override so nav tabs center correctly on mobile instead of sticking to the left
- Fix estimated annual yield in 我的配息 to use per-frequency formula (`avgYield × freq`) consistent with ETF 配息查詢

## Test plan

- [ ] On mobile, open the home page and verify ExperienceNavigation active button border fully encloses the logo icon
- [ ] On mobile, verify the tab bar spans full card width with no gap on either side
- [ ] On mobile, verify the tab bar is centered (not left-aligned)
- [ ] In 我的配息, verify the estimated yield column matches the per-lot yield shown in ETF 配息查詢 for the same stock
- [ ] In the dividend table, scroll horizontally and verify the first column does not show bleed-through from adjacent columns

https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY43XsZXK6oepEzeySCC3a)_